### PR TITLE
Fixed bug in 'IsEnabled' check. Was hardcoded to DebugLevel rather than using the log level provided in the parameter.

### DIFF
--- a/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace LibLog.Logging.LogProviders
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using FluentAssertions;
     using Serilog;
     using Serilog.Events;
@@ -20,7 +22,6 @@
                 .WriteTo.Observers(obs => obs.Subscribe(logEvent => _logEvent = logEvent))
                 .WriteTo.Console()
                 .CreateLogger();
-
 
             Log.Logger = logger;
             _sut = new SerilogLogProvider().GetLogger("Test");
@@ -62,6 +63,63 @@
         public void Can_check_is_log_level_enabled()
         {
             _sut.AssertCanCheckLogLevelsEnabled();
+        }
+
+        [Theory]
+        [InlineData(LogEventLevel.Verbose, new []{LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]
+        [InlineData(LogEventLevel.Debug, new []{LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]
+        [InlineData(LogEventLevel.Information, new[]{LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]
+        [InlineData(LogEventLevel.Warning, new[]{LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]
+        [InlineData(LogEventLevel.Error, new[]{LogLevel.Error, LogLevel.Fatal})]
+        [InlineData(LogEventLevel.Fatal, new []{LogLevel.Fatal})]
+        public void Should_enable_self_and_above_when_setup_with(LogEventLevel minimum, LogLevel[] expectedEnabledLevels)
+        {
+            AutoRollbackLoggerSetup(minimum,
+                log =>
+                {
+                    foreach (var expectedEnabled in expectedEnabledLevels)
+                    {
+                        _checkIsEnabledFor[expectedEnabled](log)
+                            .Should()
+                            .BeTrue("loglevel: '{0}' should be enabled when minimum (serilog) level is '{1}'", expectedEnabled, minimum);
+                    }
+
+                    foreach (var expectedDisabled in _allLevels.Except(expectedEnabledLevels))
+                    {
+                        _checkIsEnabledFor[expectedDisabled](log)
+                            .Should()
+                            .BeFalse("loglevel '{0}' should be diabled when minimum (serilog) level is '{1}'", expectedDisabled, minimum);
+                    }
+                });
+        }
+
+        private readonly IDictionary<LogLevel, Predicate<ILog>> _checkIsEnabledFor = new Dictionary<LogLevel, Predicate<ILog>>
+        {
+            {LogLevel.Trace, log => log.IsTraceEnabled()},
+            {LogLevel.Debug, log => log.IsDebugEnabled()},
+            {LogLevel.Info, log => log.IsInfoEnabled()},
+            {LogLevel.Warn, log => log.IsWarnEnabled()},
+            {LogLevel.Error, log => log.IsErrorEnabled()},
+            {LogLevel.Fatal, log => log.IsFatalEnabled()},
+        };
+
+        private readonly IEnumerable<LogLevel> _allLevels = Enum.GetValues(typeof (LogLevel)).Cast<LogLevel>().ToList();
+
+        private static void AutoRollbackLoggerSetup(LogEventLevel minimumLevel, Action<ILog> @do)
+        {
+            var originalLogger = Log.Logger;
+            try
+            {
+                Log.Logger = new LoggerConfiguration()
+                    .MinimumLevel.Is(minimumLevel)
+                    .CreateLogger();
+
+                @do(new SerilogLogProvider().GetLogger("Test"));
+            }
+            finally
+            {
+                Log.Logger = originalLogger;
+            }
         }
     }
 }

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -1121,7 +1121,7 @@ namespace LibLog.Logging.LogProviders
             {
                 if (messageFunc == null)
                 {
-                    return IsEnabled(_logger, DebugLevel);
+                    return IsEnabled(_logger, logLevel);
                 }
 
                 switch (logLevel)


### PR DESCRIPTION
In LibLog vs.1.4, there is a bug for the SerilogProvider. If one configure minimum log level to e.g. Info, then none of the log events logged with Info() or above will be logged. This is due to the check always being checked with DebugLevel rather than the provided LogLevel. The fix is very simple. Please see the code.

I've also added tests for bug.

Thanks for providing LibLog.

Loc
