### PR TITLE
Made LibLog PCL compatible. Related to issue #9.

### DIFF
--- a/src/LibLog.Tests/LogProviderTests.cs
+++ b/src/LibLog.Tests/LogProviderTests.cs
@@ -16,7 +16,7 @@
             EntLibLogProvider.ProviderIsAvailableOverride = false;
             SerilogLogProvider.ProviderIsAvailableOverride = false;
             LoupeLogProvider.ProviderIsAvailableOverride = false; 
-            ILog logger = LogProvider.GetCurrentClassLogger();
+            ILog logger = LogProvider.For<LogProviderTests>();
 
             ((LoggerExecutionWrapper)logger).WrappedLogger.Should().BeOfType<NLogLogProvider.NLogLogger>();
         }


### PR DESCRIPTION
Thanks for the great work on this project! I've found it really useful.

I needed PCL compatibility for a project at work. I've made a few changes for this.

* `#define PORTABLE` omits the `GetCurrentClassLogger()` method from the PCL version because this uses `StackFrame`, which is not available. This is commented out by default.
* No longer references `System.Diagnostics.TraceEventType` directly. Uses reflection instead.
* No longer references `System.Console` directly. Uses reflection instead.
* No longer references `System.ConsoleColor` directly. Uses reflection instead.

Please let me know if you think this is a sensible method of achieving PCL support.

It could make it smoother for nuget consumers if there were two versions of the file in the package. 

* One with `#define PORTABLE` **included** for portable targets
* One with `#define PORTABLE` **omitted** for .NET targets

This is beyond what I needed though!