### PR TITLE
Fix NLog string case

### DIFF
--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -531,7 +531,7 @@ namespace LibLog.Logging.LogProviders
 
         private static Type GetLogManagerType()
         {
-            return Type.GetType("NLog.LogManager, nlog");
+            return Type.GetType("NLog.LogManager, NLog");
         }
 
         private static Func<string, object> GetGetLoggerMethodCall()


### PR DESCRIPTION
Mono will only correctly return the type when the type name string is correctly capitalized.
