### PR TITLE
Diagnostic context support (NDC and MDC) with implementations for NLog, Log4Net and Serilog

### DIFF
--- a/src/LibLog.Tests/LogProviders/ColouredConsoleProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/ColouredConsoleProviderLoggingTests.cs
@@ -2,19 +2,15 @@
 {
     using System;
     using System.IO;
-
     using FluentAssertions;
-
     using Xunit;
     using Xunit.Extensions;
 
-    public class ColouredConsoleProviderLoggingTests
+    public class ColouredConsoleProviderLoggingTests : IDisposable
     {
         private readonly ILog _sut;
-
         private readonly TextWriter _originalConsoleOut;
-
-        private StringWriter _target;
+        private readonly StringWriter _target;
 
         public ColouredConsoleProviderLoggingTests()
         {
@@ -43,7 +39,7 @@
         public void Should_be_able_to_log_message(LogLevel logLevel)
         {
             _sut.Log(logLevel, () => "m");
-            _target.ToString().Trim().Should().Be(logLevel.ToString() + "|m|");
+            _target.ToString().Trim().Should().Be(logLevel + "|m|");
         }
 
         [Theory]
@@ -57,7 +53,7 @@
         {
             _sut.Log(logLevel, () => "m", new Exception("e"));
 
-            _target.ToString().Trim().Should().Be(logLevel.ToString() + "|m|e");
+            _target.ToString().Trim().Should().Be(logLevel + "|m|e");
         }
 
         [Fact]

--- a/src/LibLog.Tests/LogProviders/Log4NetLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/Log4NetLogProviderLoggingTests.cs
@@ -15,11 +15,13 @@
     {
         private readonly MemoryAppender _memoryAppender;
         private readonly ILog _sut;
+        private readonly ILogProvider _logProvider;
 
         public Log4NetLogProviderLoggingTests()
         {
             _memoryAppender = new MemoryAppender();
             BasicConfigurator.Configure(_memoryAppender);
+            _logProvider = new Log4NetLogProvider();
             _sut = new Log4NetLogProvider().GetLogger("Test");
         }
 
@@ -60,6 +62,32 @@
         public void Can_check_is_log_level_enabled()
         {
             _sut.AssertCanCheckLogLevelsEnabled();
+        }
+
+        [Fact]
+        public void Can_open_nested_diagnostics_context()
+        {
+            using (_logProvider.OpenNestedContext("context"))
+            {
+                _sut.Info("m");
+                var loggingEvent = _memoryAppender.GetEvents().Single();
+
+                loggingEvent.Properties.GetKeys().Should().Contain("NDC");
+                loggingEvent.Properties["NDC"].Should().Be("context");
+            }
+        }
+
+        [Fact]
+        public void Can_open_mapped_diagnostics_context()
+        {
+            using (_logProvider.OpenMappedContext("key", "value"))
+            {
+                _sut.Info("m");
+                var loggingEvent = _memoryAppender.GetEvents().Single();
+
+                loggingEvent.Properties.GetKeys().Should().Contain("key");
+                loggingEvent.Properties["key"].Should().Be("value");
+            }
         }
 
         private string GetSingleMessage()

--- a/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
@@ -13,17 +13,19 @@
     {
         private readonly ILog _sut;
         private readonly MemoryTarget _target;
+        private ILogProvider _logProvider;
 
         public NLogLogProviderLoggingTests()
         {
             var config = new LoggingConfiguration();
             _target = new MemoryTarget
             {
-                Layout = "${level:uppercase=true}|${message}|${exception}"
+                Layout = "${level:uppercase=true}|${ndc}|${mdc:item=key}|${message}|${exception}"
             };
             config.AddTarget("memory", _target);
             config.LoggingRules.Add(new LoggingRule("*", NLog.LogLevel.Trace, _target));
             LogManager.Configuration = config;
+            _logProvider = new NLogLogProvider();
             _sut = new NLogLogProvider().GetLogger("Test");
         }
 
@@ -43,7 +45,7 @@
         {
             _sut.Log(logLevel, () => "m");
 
-            _target.Logs[0].Should().Be(messagePrefix + "|m|");
+            _target.Logs[0].Should().Be(messagePrefix + "|||m|");
         }
 
         [Theory]
@@ -57,13 +59,33 @@
         {
             _sut.Log(logLevel, () => "m", new Exception("e"));
 
-            _target.Logs[0].Should().Be(messagePrefix + "|m|e");
+            _target.Logs[0].Should().Be(messagePrefix + "|||m|e");
         }
 
         [Fact]
         public void Can_check_is_log_level_enabled()
         {
            _sut.AssertCanCheckLogLevelsEnabled();
+        }
+
+        [Fact]
+        public void Can_open_nested_diagnostics_context()
+        {
+            using (_logProvider.OpenNestedContext("context"))
+            {
+                _sut.Info("m");
+                _target.Logs[0].Should().Be("INFO|context||m|");
+            }
+        }
+
+        [Fact]
+        public void Can_open_mapped_diagnostics_context()
+        {
+            using (_logProvider.OpenMappedContext("key", "value"))
+            {
+                _sut.Info("m");
+                _target.Logs[0].Should().Be("INFO||value|m|");
+            }
         }
     }
 }

--- a/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
@@ -14,17 +14,30 @@
     {
         private readonly ILog _sut;
         private LogEvent _logEvent;
+        private readonly SerilogLogProvider _logProvider;
+        private readonly IEnumerable<LogLevel> _allLevels = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToList();
+        private readonly IDictionary<LogLevel, Predicate<ILog>> _checkIsEnabledFor = new Dictionary<LogLevel, Predicate<ILog>>
+        {
+            {LogLevel.Trace, log => log.IsTraceEnabled()},
+            {LogLevel.Debug, log => log.IsDebugEnabled()},
+            {LogLevel.Info, log => log.IsInfoEnabled()},
+            {LogLevel.Warn, log => log.IsWarnEnabled()},
+            {LogLevel.Error, log => log.IsErrorEnabled()},
+            {LogLevel.Fatal, log => log.IsFatalEnabled()},
+        };
 
         public SerilogLogProviderLoggingTests()
         {
             var logger = new LoggerConfiguration()
+                .Enrich.FromLogContext()
                 .MinimumLevel.Is(LogEventLevel.Verbose)
                 .WriteTo.Observers(obs => obs.Subscribe(logEvent => _logEvent = logEvent))
                 .WriteTo.Console()
                 .CreateLogger();
 
             Log.Logger = logger;
-            _sut = new SerilogLogProvider().GetLogger("Test");
+            _logProvider = new SerilogLogProvider();
+            _sut = _logProvider.GetLogger("Test");
         }
 
         [Theory]
@@ -65,6 +78,30 @@
             _sut.AssertCanCheckLogLevelsEnabled();
         }
 
+        [Fact]
+        public void Can_open_nested_diagnostics_context()
+        {
+            using (_logProvider.OpenNestedContext("context"))
+            {
+                _sut.Info("m");
+
+                _logEvent.Properties.Keys.Should().Contain("NDC");
+                _logEvent.Properties["NDC"].ToString().Should().Be("\"context\"");
+            }
+        }
+
+        [Fact]
+        public void Can_open_mapped_diagnostics_context()
+        {
+            using (_logProvider.OpenMappedContext("key", "value"))
+            {
+                _sut.Info("m");
+
+                _logEvent.Properties.Keys.Should().Contain("key");
+                _logEvent.Properties["key"].ToString().Should().Be("\"value\"");
+            }
+        }
+
         [Theory]
         [InlineData(LogEventLevel.Verbose, new []{LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]
         [InlineData(LogEventLevel.Debug, new []{LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]
@@ -92,18 +129,6 @@
                     }
                 });
         }
-
-        private readonly IDictionary<LogLevel, Predicate<ILog>> _checkIsEnabledFor = new Dictionary<LogLevel, Predicate<ILog>>
-        {
-            {LogLevel.Trace, log => log.IsTraceEnabled()},
-            {LogLevel.Debug, log => log.IsDebugEnabled()},
-            {LogLevel.Info, log => log.IsInfoEnabled()},
-            {LogLevel.Warn, log => log.IsWarnEnabled()},
-            {LogLevel.Error, log => log.IsErrorEnabled()},
-            {LogLevel.Fatal, log => log.IsFatalEnabled()},
-        };
-
-        private readonly IEnumerable<LogLevel> _allLevels = Enum.GetValues(typeof (LogLevel)).Cast<LogLevel>().ToList();
 
         private static void AutoRollbackLoggerSetup(LogEventLevel minimumLevel, Action<ILog> @do)
         {

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -316,9 +316,12 @@ namespace LibLog.Logging
     public interface ILogProvider
     {
         ILog GetLogger(string name);
+
+        IDisposable OpenNestedContext(string message);
+
+        IDisposable OpenMappedContext(string key, string value);
     }
-
-
+    
     /// <summary>
     /// Provides a mechanism to create instances of <see cref="ILog" /> objects.
     /// </summary>
@@ -374,6 +377,26 @@ namespace LibLog.Logging
         public static void SetCurrentLogProvider(ILogProvider logProvider)
         {
             _currentLogProvider = logProvider;
+        }
+
+        public static IDisposable OpenNestedConext(string message)
+        {
+            if(_currentLogProvider == null)
+            {
+                throw new InvalidOperationException("Current Log Provider is not set. Call SetCurrentLogProvider " +
+                                                    "with a non-null value first.");
+            }
+            return _currentLogProvider.OpenNestedContext(message);
+        }
+
+        public static IDisposable OpenMappedContext(string key, string value)
+        {
+            if (_currentLogProvider == null)
+            {
+                throw new InvalidOperationException("Current Log Provider is not set. Call SetCurrentLogProvider " +
+                                                    "with a non-null value first.");
+            }
+            return _currentLogProvider.OpenMappedContext(key, value);
         }
 
         public delegate bool IsLoggerAvailable();
@@ -469,9 +492,48 @@ namespace LibLog.Logging.LogProviders
     using System.Linq.Expressions;
     using System.Reflection;
     using System.Text;
-    using System.Threading;
 
-    public class NLogLogProvider : ILogProvider
+    public abstract class LogProviderBase : ILogProvider
+    {
+        protected delegate IDisposable OpenNdc(string message);
+        protected delegate IDisposable OpenMdc(string key, string value);
+
+        private readonly Lazy<OpenNdc> _lazyOpenNdcMethod;
+        private readonly Lazy<OpenMdc> _lazyOpenMdcMethod;
+        private static readonly IDisposable NoopDisposableInstance = new DisposableAction();
+
+        protected LogProviderBase()
+        {
+            _lazyOpenNdcMethod 
+                = new Lazy<OpenNdc>(GetOpenNdcMethod);
+            _lazyOpenMdcMethod
+               = new Lazy<OpenMdc>(GetOpenMdcMethod);
+        }
+
+        public abstract ILog GetLogger(string name);
+        
+        public IDisposable OpenNestedContext(string message)
+        {
+            return _lazyOpenNdcMethod.Value(message);
+        }
+
+        public IDisposable OpenMappedContext(string key, string value)
+        {
+            return _lazyOpenMdcMethod.Value(key, value);
+        }
+
+        protected virtual OpenNdc GetOpenNdcMethod()
+        {
+            return _ => NoopDisposableInstance;
+        }
+
+        protected virtual OpenMdc GetOpenMdcMethod()
+        {
+            return (_, __) => NoopDisposableInstance;
+        }
+    }
+
+    public class NLogLogProvider : LogProviderBase
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
         private static bool _providerIsAvailableOverride = true;
@@ -491,7 +553,7 @@ namespace LibLog.Logging.LogProviders
             set { _providerIsAvailableOverride = value; }
         }
 
-        public ILog GetLogger(string name)
+        public override ILog GetLogger(string name)
         {
             return new NLogLogger(_getLoggerByNameDelegate(name));
         }
@@ -499,6 +561,41 @@ namespace LibLog.Logging.LogProviders
         public static bool IsLoggerAvailable()
         {
             return ProviderIsAvailableOverride && GetLogManagerType() != null;
+        }
+
+        protected override OpenNdc GetOpenNdcMethod()
+        {
+            Type ndcContextType = Type.GetType("NLog.NestedDiagnosticsContext, NLog");
+            MethodInfo method = ndcContextType.GetMethod("Push", new[] { typeof(string) });
+            ParameterExpression messageParam = Expression.Parameter(typeof(string), "message");
+            MethodCallExpression methodCall = Expression.Call(null, method, messageParam);
+            return Expression.Lambda<OpenNdc>(methodCall, messageParam).Compile();
+        }
+
+        protected override OpenMdc GetOpenMdcMethod()
+        {
+            Type mdcContextType = Type.GetType("NLog.MappedDiagnosticsContext, NLog");
+
+            MethodInfo setMethod = mdcContextType.GetMethod("Set", new[] { typeof(string), typeof(string) });
+            MethodInfo removeMethod = mdcContextType.GetMethod("Remove", new[] { typeof(string) });
+            ParameterExpression keyParam = Expression.Parameter(typeof(string), "key");
+            ParameterExpression valueParam = Expression.Parameter(typeof(string), "value");
+
+            MethodCallExpression setMethodCall = Expression.Call(null, setMethod, keyParam, valueParam);
+            MethodCallExpression removeMethodCall = Expression.Call(null, removeMethod, keyParam);
+
+            Action<string, string> set = Expression
+                .Lambda<Action<string, string>>(setMethodCall, keyParam, valueParam)
+                .Compile();
+            Action<string> remove = Expression
+                .Lambda<Action<string>>(removeMethodCall, keyParam)
+                .Compile();
+
+            return (key, value) =>
+            {
+                set(key, value);
+                return new DisposableAction(() => remove(key));
+            };
         }
 
         private static Type GetLogManagerType()
@@ -511,8 +608,8 @@ namespace LibLog.Logging.LogProviders
             Type logManagerType = GetLogManagerType();
             MethodInfo method = logManagerType.GetMethod("GetLogger", new[] { typeof(string) });
             ParameterExpression nameParam = Expression.Parameter(typeof(string), "name");
-            MethodCallExpression methodCall = Expression.Call(null, method, new Expression[] { nameParam });
-            return Expression.Lambda<Func<string, object>>(methodCall, new[] { nameParam }).Compile();
+            MethodCallExpression methodCall = Expression.Call(null, method, nameParam);
+            return Expression.Lambda<Func<string, object>>(methodCall, nameParam).Compile();
         }
 
         public class NLogLogger : ILog
@@ -653,7 +750,7 @@ namespace LibLog.Logging.LogProviders
         }
     }
 
-    public class Log4NetLogProvider : ILogProvider
+    public class Log4NetLogProvider : LogProviderBase
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
         private static bool _providerIsAvailableOverride = true;
@@ -673,7 +770,7 @@ namespace LibLog.Logging.LogProviders
             set { _providerIsAvailableOverride = value; }
         }
 
-        public ILog GetLogger(string name)
+        public override ILog GetLogger(string name)
         {
             return new Log4NetLogger(_getLoggerByNameDelegate(name));
         }
@@ -821,7 +918,7 @@ namespace LibLog.Logging.LogProviders
         }
     }
 
-    public class EntLibLogProvider : ILogProvider
+    public class EntLibLogProvider : LogProviderBase
     {
         private const string TypeTemplate = "Microsoft.Practices.EnterpriseLibrary.Logging.{0}, Microsoft.Practices.EnterpriseLibrary.Logging";
         private static bool _providerIsAvailableOverride = true;
@@ -856,7 +953,7 @@ namespace LibLog.Logging.LogProviders
             set { _providerIsAvailableOverride = value; }
         }
 
-        public ILog GetLogger(string name)
+        public override ILog GetLogger(string name)
         {
             return new EntLibLogger(name, WriteLogEntry, ShouldLogEntry);
         }
@@ -978,7 +1075,7 @@ namespace LibLog.Logging.LogProviders
         }
     }
 
-    public class SerilogLogProvider : ILogProvider
+    public class SerilogLogProvider : LogProviderBase
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
         private static bool _providerIsAvailableOverride = true;
@@ -998,7 +1095,7 @@ namespace LibLog.Logging.LogProviders
             set { _providerIsAvailableOverride = value; }
         }
 
-        public ILog GetLogger(string name)
+        public override ILog GetLogger(string name)
         {
             return new SerilogLogger(_getLoggerByNameDelegate(name));
         }
@@ -1227,7 +1324,7 @@ namespace LibLog.Logging.LogProviders
         }
     }
 
-    public class LoupeLogProvider : ILogProvider
+    public class LoupeLogProvider : LogProviderBase
     {
         private static bool _providerIsAvailableOverride = true;
         private readonly WriteDelegate _logWriteDelegate;
@@ -1254,7 +1351,7 @@ namespace LibLog.Logging.LogProviders
             set { _providerIsAvailableOverride = value; }
         }
 
-        public ILog GetLogger(string name)
+        public override ILog GetLogger(string name)
         {
             return new LoupeLogger(name, _logWriteDelegate);
         }
@@ -1354,7 +1451,7 @@ namespace LibLog.Logging.LogProviders
             );
     }
 
-    public class ColouredConsoleLogProvider : ILogProvider
+    public class ColouredConsoleLogProvider : LogProviderBase
     {
         static ColouredConsoleLogProvider()
         {
@@ -1369,7 +1466,7 @@ namespace LibLog.Logging.LogProviders
                     };
         }
 
-        public ILog GetLogger(string name)
+        public override ILog GetLogger(string name)
         {
             return new ColouredConsoleLogger(name);
         }
@@ -1461,6 +1558,24 @@ namespace LibLog.Logging.LogProviders
                 {
                     Console.Out.WriteLine(formattedMessage);
                 }
+            }
+        }
+    }
+
+    internal class DisposableAction : IDisposable
+    {
+        private readonly Action _onDispose;
+
+        public DisposableAction(Action onDispose = null)
+        {
+            _onDispose = onDispose;
+        }
+
+        public void Dispose()
+        {
+            if(_onDispose != null)
+            {
+                _onDispose();
             }
         }
     }


### PR DESCRIPTION
It appears that EntLib Logging [doesn't support the concept](https://entlib.codeplex.com/discussions/3523); though this is out of date, if anyone knows if it's possible, please let me know how.

LoupeLog support: awaiting response from @kendallmiller on pointers on how to.