### PR TITLE
Fixed curly braces logging issue

### DIFF
--- a/src/LibLog.Tests/LogProviders/ColouredConsoleProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/ColouredConsoleProviderLoggingTests.cs
@@ -83,6 +83,28 @@
             _target.ToString().Trim().Should().Be(logLevel.ToString() + "|m replaced|e");
         }
 
+        [Theory]
+        [InlineData(LogLevel.Debug)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Fatal)]
+        [InlineData(LogLevel.Info)]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Warn)]
+        public void Should_be_able_to_log_message_if_contains_brackets(LogLevel logLevel)
+        {
+            _sut.Log(logLevel, () => "m {ab c}", new Exception("e"));
+
+            _target.ToString().Trim().Should().Be(logLevel.ToString() + "|m {ab c}|e");
+        }
+
+        [Fact]
+        public void Should_log_message_with_curly_brackets()
+        {
+            _sut.Log(LogLevel.Debug, () => "Query language substitutions: {'true'='1', 'false'='0', 'yes'=''Y'', 'no'=''N''}");
+
+            _target.ToString().Should().Be("Debug|Query language substitutions: {'true'='1', 'false'='0', 'yes'=''Y'', 'no'=''N''}|\r\n");
+        }
+
         [Fact]
         public void Can_check_is_log_level_enabled()
         {

--- a/src/LibLog.Tests/LogProviders/EntLibLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/EntLibLogProviderLoggingTests.cs
@@ -78,6 +78,14 @@
             Target.Logs[0].Severity.Should().Be(severity);
         }
 
+        [Fact]
+        public void Should_log_message_with_curly_brackets()
+        {
+            Sut.Log(LogLevel.Debug, () => "Query language substitutions: {'true'='1', 'false'='0', 'yes'=''Y'', 'no'=''N''}");
+
+            Target.Logs[0].Message.Should().Contain("Query language substitutions: {'true'='1', 'false'='0', 'yes'=''Y'', 'no'=''N''}");
+        }
+
         [Theory]
         [InlineData(LogLevel.Debug, TraceEventType.Verbose)]
         [InlineData(LogLevel.Error, TraceEventType.Error)]

--- a/src/LibLog.Tests/LogProviders/Log4NetLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/Log4NetLogProviderLoggingTests.cs
@@ -118,6 +118,14 @@
             }
         }
 
+        [Fact]
+        public void Should_log_message_with_curly_brackets()
+        {
+            _sut.Log(LogLevel.Debug, () => "Query language substitutions: {'true'='1', 'false'='0', 'yes'=''Y'', 'no'=''N''}");
+
+            GetSingleMessage().Should().Contain("DEBUG|Query language substitutions: {'true'='1', 'false'='0', 'yes'=''Y'', 'no'=''N''}");
+        }
+
         private string GetSingleMessage()
         {
             LoggingEvent loggingEvent = _memoryAppender.GetEvents().Single();

--- a/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
@@ -107,6 +107,14 @@
         }
 
         [Fact]
+        public void Should_log_message_with_curly_brackets()
+        {
+            _sut.Log(LogLevel.Debug, () => "Query language substitutions: {'true'='1', 'false'='0', 'yes'=''Y'', 'no'=''N''}");
+
+            _target.Logs[0].Should().Contain("DEBUG|||Query language substitutions: {'true'='1', 'false'='0', 'yes'=''Y'', 'no'=''N''}");
+        }
+
+        [Fact]
         public void Can_open_mapped_diagnostics_context()
         {
             using (_logProvider.OpenMappedContext("key", "value"))

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -1824,7 +1824,7 @@ namespace LibLog.Logging.LogProviders
         /// <returns></returns>
         public static Func<string> SimulateStructuredLogging(Func<string> messageBuilder, object[] formatParameters)
         {
-            if(formatParameters == null || !formatParameters.Any())
+            if(formatParameters == null || !formatParameters.Length == 0)
             {
                 return messageBuilder;
             }

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -523,6 +523,7 @@ namespace LibLog.Logging.LogProviders
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
     using System.Text;
@@ -1823,7 +1824,7 @@ namespace LibLog.Logging.LogProviders
         /// <returns></returns>
         public static Func<string> SimulateStructuredLogging(Func<string> messageBuilder, object[] formatParameters)
         {
-            if(formatParameters == null)
+            if(formatParameters == null || !formatParameters.Any())
             {
                 return messageBuilder;
             }


### PR DESCRIPTION
If you logged a message **without** format parameters, it would still go through String.Format. 

By checking for parameters.Any(), it no longer does this. 