### PR TITLE
Prevent inlining of GetCurrentClassLogger

### DIFF
--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -428,6 +428,7 @@ namespace LibLog.Logging
         /// Gets a logger for the current class.
         /// </summary>
         /// <returns>An instance of <see cref="ILog"/></returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
 #if LIBLOG_PUBLIC
         public
 #else


### PR DESCRIPTION
YOLO'd via the GitHub UI

fixes #52 