### PR TITLE
[WIP] Disable logging at runtime

### DIFF
--- a/src/LibLog.Tests/LibLogPCL.Tests.csproj
+++ b/src/LibLog.Tests/LibLogPCL.Tests.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG; LIBLOG_PORTABLE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -30,7 +30,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE; LIBLOG_PORTABLE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>

--- a/src/LibLog.Tests/LogProviderTests.cs
+++ b/src/LibLog.Tests/LogProviderTests.cs
@@ -139,7 +139,7 @@
             var logger = LogProvider.GetLogger("DisableLogging");
             logger.Info("test");
 
-            target.Logs.Should().BeEmpty();
+            target.Logs.Should().NotBeEmpty();
         }
 
         [Fact]

--- a/src/LibLog.Tests/LogProviderTests.cs
+++ b/src/LibLog.Tests/LogProviderTests.cs
@@ -177,7 +177,7 @@
             LogManager.Configuration = config;
             LogProvider.SetCurrentLogProvider(new NLogLogProvider());
 
-            Environment.SetEnvironmentVariable("$rootnamespace$_LIBLOG_DISABLE", "true");
+            Environment.SetEnvironmentVariable(LogProvider.DisableLoggingEnvironmentVariable, "true");
             var logger = LogProvider.GetLogger("DisableLogging");
             logger.Info("test");
 
@@ -187,7 +187,7 @@
         [Fact]
         public void When_enable_logging_via_env_var_then_should_log()
         {
-            Environment.SetEnvironmentVariable("$rootnamespace$_LIBLOG_DISABLE", "true");
+            Environment.SetEnvironmentVariable(LogProvider.DisableLoggingEnvironmentVariable, "true");
             var config = new LoggingConfiguration();
             var target = new MemoryTarget
             {
@@ -198,7 +198,7 @@
             LogManager.Configuration = config;
             LogProvider.SetCurrentLogProvider(new NLogLogProvider());
 
-            Environment.SetEnvironmentVariable("$rootnamespace$_LIBLOG_DISABLE", "false");
+            Environment.SetEnvironmentVariable(LogProvider.DisableLoggingEnvironmentVariable, "false");
             var logger = LogProvider.GetLogger("DisableLogging");
             logger.Info("test");
 
@@ -214,6 +214,9 @@
             SerilogLogProvider.ProviderIsAvailableOverride = true;
             LoupeLogProvider.ProviderIsAvailableOverride = true;
             ColouredConsoleLogProvider.ProviderIsAvailableOverride = true;
+#if !LIBLOG_PORTABLE
+            Environment.SetEnvironmentVariable(LogProvider.DisableLoggingEnvironmentVariable, "false");
+#endif
         }
     }
 }

--- a/src/LibLog.Tests/LogProviderTests.cs
+++ b/src/LibLog.Tests/LogProviderTests.cs
@@ -123,7 +123,7 @@
         }
 
         [Fact]
-        public void Can_disable_logging()
+        public void When_disable_logging_via_property_then_should_not_log()
         {
             var config = new LoggingConfiguration();
             var target = new MemoryTarget
@@ -135,7 +135,7 @@
             LogManager.Configuration = config;
             LogProvider.SetCurrentLogProvider(new NLogLogProvider());
 
-            LogProvider.IsLoggingEnabled = false;
+            LogProvider.IsDisabled = true;
             var logger = LogProvider.GetLogger("DisableLogging");
             logger.Info("test");
 
@@ -143,9 +143,9 @@
         }
 
         [Fact]
-        public void Can_enable_logging()
+        public void When_enable_logging_via_property_then_should_log()
         {
-            LogProvider.IsLoggingEnabled = false;
+            LogProvider.IsDisabled = true;
             var config = new LoggingConfiguration();
             var target = new MemoryTarget
             {
@@ -156,12 +156,55 @@
             LogManager.Configuration = config;
             LogProvider.SetCurrentLogProvider(new NLogLogProvider());
 
-            LogProvider.IsLoggingEnabled = true;
+            LogProvider.IsDisabled = false;
             var logger = LogProvider.GetLogger("DisableLogging");
             logger.Info("test");
 
             target.Logs.Should().NotBeEmpty();
         }
+
+#if  !LIBLOG_PORTABLE
+        [Fact]
+        public void When_disable_logging_via_env_var_then_should_not_log()
+        {
+            var config = new LoggingConfiguration();
+            var target = new MemoryTarget
+            {
+                Layout = "${level:uppercase=true}|${ndc}|${mdc:item=key}|${message}|${exception}"
+            };
+            config.AddTarget("memory", target);
+            config.LoggingRules.Add(new LoggingRule("*", NLog.LogLevel.Trace, target));
+            LogManager.Configuration = config;
+            LogProvider.SetCurrentLogProvider(new NLogLogProvider());
+
+            Environment.SetEnvironmentVariable("$rootnamespace$_LIBLOG_DISABLE", "true");
+            var logger = LogProvider.GetLogger("DisableLogging");
+            logger.Info("test");
+
+            target.Logs.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_enable_logging_via_env_var_then_should_log()
+        {
+            Environment.SetEnvironmentVariable("$rootnamespace$_LIBLOG_DISABLE", "true");
+            var config = new LoggingConfiguration();
+            var target = new MemoryTarget
+            {
+                Layout = "${level:uppercase=true}|${ndc}|${mdc:item=key}|${message}|${exception}"
+            };
+            config.AddTarget("memory", target);
+            config.LoggingRules.Add(new LoggingRule("*", NLog.LogLevel.Trace, target));
+            LogManager.Configuration = config;
+            LogProvider.SetCurrentLogProvider(new NLogLogProvider());
+
+            Environment.SetEnvironmentVariable("$rootnamespace$_LIBLOG_DISABLE", "false");
+            var logger = LogProvider.GetLogger("DisableLogging");
+            logger.Info("test");
+
+            target.Logs.Should().NotBeEmpty();
+        }
+#endif
 
         public void Dispose()
         {

--- a/src/LibLog.Tests/LogProviderTests.cs
+++ b/src/LibLog.Tests/LogProviderTests.cs
@@ -139,7 +139,7 @@
             var logger = LogProvider.GetLogger("DisableLogging");
             logger.Info("test");
 
-            target.Logs.Should().NotBeEmpty();
+            target.Logs.Should().BeEmpty();
         }
 
         [Fact]

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -370,6 +370,11 @@ namespace LibLog.Logging
     /// </summary>
     public static class LogProvider
     {
+        /// <summary>
+        /// The disable logging environment variable. If the environment variable is set to 'true', then logging
+        /// will be disabled.
+        /// </summary>
+        public const string DisableLoggingEnvironmentVariable = "$rootnamespace$_LIBLOG_DISABLE";
         private const string NullLogProvider = "Current Log Provider is not set. Call SetCurrentLogProvider " +
                                                "with a non-null value first.";
         private static dynamic _currentLogProvider;
@@ -592,7 +597,6 @@ namespace LibLog.Logging
         private readonly Logger _logger;
         private readonly Func<bool> _getIsDisabled;
         internal const string FailedToGenerateLogMessage = "Failed to generate log message";
-        private const string EnvironmentVar = "$rootnamespace$_LIBLOG_DISABLE";
 
         internal LoggerExecutionWrapper(Logger logger, Func<bool> getIsDisabled = null)
         {
@@ -613,7 +617,7 @@ namespace LibLog.Logging
                 return false;
             }
 #else
-            var envVar = Environment.GetEnvironmentVariable(EnvironmentVar);
+            var envVar = Environment.GetEnvironmentVariable(LogProvider.DisableLoggingEnvironmentVariable);
 
             if (_getIsDisabled() || (envVar != null && envVar.Equals("true", StringComparison.OrdinalIgnoreCase)))
             {

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -375,6 +375,11 @@ namespace LibLog.Logging
         private static dynamic _currentLogProvider;
         private static Action<ILogProvider> _onCurrentLogProviderSet;
 
+        static LogProvider()
+        {
+            IsLoggingEnabled = true;
+        }
+
         /// <summary>
         /// Sets the current log provider.
         /// </summary>
@@ -385,6 +390,14 @@ namespace LibLog.Logging
 
             RaiseOnCurrentLogProviderSet();
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this is logging enabled.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is logging enabled; otherwise, <c>false</c>.
+        /// </value>
+        public static bool IsLoggingEnabled { get; set; }
 
         /// <summary>
         /// Sets an action that is invoked when a consumer of your library has called SetCurrentLogProvider. It is 
@@ -469,8 +482,12 @@ namespace LibLog.Logging
 #endif
         static ILog GetLogger(string name)
         {
+            if(!IsLoggingEnabled)
+            {
+                return NoOpLogger.Instance;
+            }
             ILogProvider logProvider = CurrentLogProvider ?? ResolveLogProvider();
-            return logProvider == null ? new NoOpLogger() : (ILog)new LoggerExecutionWrapper(logProvider.GetLogger(name));
+            return logProvider == null ? NoOpLogger.Instance : (ILog)new LoggerExecutionWrapper(logProvider.GetLogger(name));
         }
 
         /// <summary>
@@ -563,6 +580,8 @@ namespace LibLog.Logging
 
         internal class NoOpLogger : ILog
         {
+            internal static readonly NoOpLogger Instance = new NoOpLogger();
+
             public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
             {
                 return false;

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -482,12 +482,10 @@ namespace LibLog.Logging
 #endif
         static ILog GetLogger(string name)
         {
-            if(!IsLoggingEnabled)
-            {
-                return NoOpLogger.Instance;
-            }
             ILogProvider logProvider = CurrentLogProvider ?? ResolveLogProvider();
-            return logProvider == null ? NoOpLogger.Instance : (ILog)new LoggerExecutionWrapper(logProvider.GetLogger(name));
+            return logProvider == null 
+                ? NoOpLogger.Instance
+                : (ILog)new LoggerExecutionWrapper(logProvider.GetLogger(name), () => IsLoggingEnabled);
         }
 
         /// <summary>
@@ -592,11 +590,13 @@ namespace LibLog.Logging
     internal class LoggerExecutionWrapper : ILog
     {
         private readonly Logger _logger;
+        private readonly Func<bool> _isEnabled;
         internal const string FailedToGenerateLogMessage = "Failed to generate log message";
 
-        internal LoggerExecutionWrapper(Logger logger)
+        internal LoggerExecutionWrapper(Logger logger, Func<bool> isLoggingEnabled = null)
         {
             _logger = logger;
+            _isEnabled = isLoggingEnabled ?? (() => true);
         }
 
         internal Logger WrappedLogger

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -606,6 +606,11 @@ namespace LibLog.Logging
 
         public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters)
         {
+            if(!_isLoggingEnabled())
+            {
+                return false;
+            }
+
             if (messageFunc == null)
             {
                 return _logger(logLevel, null);

--- a/src/LibLog/LibLog.nuspec
+++ b/src/LibLog/LibLog.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>LibLog</id>
-        <version>4.0.2</version>
+        <version>4.1.0</version>
         <authors>Damian Hickey</authors>
         <owners>Damian Hickey</owners>
         <licenseUrl>https://github.com/damianh/LibLog/blob/master/licence.txt</licenseUrl>

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -14,5 +14,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.0.0.0")]
+[assembly: AssemblyVersion("4.1.0.0")]
+[assembly: AssemblyFileVersion("4.1.0.0")]


### PR DESCRIPTION
Addresses #50 

Exercised via `YourLib.Logging.LogProvider.IsLoggingEnabled = false`. The `LoggerExecutionWrapper` will check this each call. This means it's safe for both statically initialized logger fields and instance fields/ local instances.

@leastprivilege the issue problem with the Env Var approach is that it will disable Logging for _all_ libraries that use LibLog. Is this desirable / wise? If I could get {YourNamespace}_LIBLOG_DISABLE working, would that be better?