### PR TITLE
Changes the root namespace from `LibLog` to `YourRootNamespace`

### DIFF
--- a/default.ps1
+++ b/default.ps1
@@ -1,48 +1,48 @@
 properties {
-	$projectName = "LibLog"
-	$buildNumber = 0
-	$rootDir  = Resolve-Path .\
-	$buildOutputDir = "$rootDir\build"
-	$reportsDir = "$buildOutputDir\reports"
-	$srcDir = "$rootDir\src"
-	$solutionFilePath = "$srcDir\$projectName.sln"
+    $projectName = "LibLog"
+    $buildNumber = 0
+    $rootDir  = Resolve-Path .\
+    $buildOutputDir = "$rootDir\build"
+    $reportsDir = "$buildOutputDir\reports"
+    $srcDir = "$rootDir\src"
+    $solutionFilePath = "$srcDir\$projectName.sln"
 }
 
 task default -depends RunTests, CreateNuGetPackage
 
 task Clean {
-	Remove-Item $buildOutputDir -Force -Recurse -ErrorAction SilentlyContinue
-	exec { msbuild /nologo /verbosity:quiet $solutionFilePath /t:Clean }
+    Remove-Item $buildOutputDir -Force -Recurse -ErrorAction SilentlyContinue
+    exec { msbuild /nologo /verbosity:quiet $solutionFilePath /t:Clean }
 }
 
 task Compile {
-	exec { msbuild /nologo /verbosity:quiet $solutionFilePath /p:Configuration=Release }
+    exec { msbuild /nologo /verbosity:quiet $solutionFilePath /p:Configuration=Release }
 }
 
 task RunTests -depends Compile {
-	$xunitRunner = "$srcDir\packages\xunit.runners.1.9.2\tools\xunit.console.clr4.exe"
-	gci . -Recurse -Include *Tests.csproj, Tests.*.csproj | % {
-		$project = $_.BaseName
-		if(!(Test-Path $reportsDir\xUnit\$project)){
-			New-Item $reportsDir\xUnit\$project -Type Directory
-		}
+    $xunitRunner = "$srcDir\packages\xunit.runners.1.9.2\tools\xunit.console.clr4.exe"
+    gci . -Recurse -Include *Tests.csproj, Tests.*.csproj | % {
+        $project = $_.BaseName
+        if(!(Test-Path $reportsDir\xUnit\$project)){
+            New-Item $reportsDir\xUnit\$project -Type Directory
+        }
         .$xunitRunner "$srcDir\$project\bin\Release\$project.dll" /html "$reportsDir\xUnit\$project\index.html"
     }
 }
 
 task CreatePP {
-	(Get-Content $srcDir\$projectName\$projectName.cs) | Foreach-Object {
-		$_ -replace 'namespace LibLog', 'namespace $rootnamespace$' `
-		-replace 'using global::LibLog', 'using $rootnamespace$'
-		} | Set-Content $buildOutputDir\$projectName.cs.pp -Encoding UTF8
+    (Get-Content $srcDir\$projectName\$projectName.cs) | Foreach-Object {
+        $_ -replace 'namespace YourRootNamespace', 'namespace $rootnamespace$' `
+        -replace 'using global::YourRootNamespace', 'using $rootnamespace$'
+        } | Set-Content $buildOutputDir\$projectName.cs.pp -Encoding UTF8
 }
 
 task CreateNuGetPackage -depends CreatePP {
-	$nuspecFilePath = "$buildOutputDir\$projectName.nuspec"
-	Copy-Item $srcDir\$projectName\$projectName.nuspec $nuspecFilePath
+    $nuspecFilePath = "$buildOutputDir\$projectName.nuspec"
+    Copy-Item $srcDir\$projectName\$projectName.nuspec $nuspecFilePath
 
-	[Xml]$fileContents = Get-Content -Path $nuspecFilePath
-	$fileContents.package.metadata.version
-	$packageVersion = $fileContents.package.metadata.version + "-build" + $buildNumber.ToString().PadLeft(5,'0')
-	.$srcDir\.nuget\nuget.exe pack $nuspecFilePath -o $buildOutputDir -version $packageVersion
+    [Xml]$fileContents = Get-Content -Path $nuspecFilePath
+    $fileContents.package.metadata.version
+    $packageVersion = $fileContents.package.metadata.version + "-build" + $buildNumber.ToString().PadLeft(5,'0')
+    .$srcDir\.nuget\nuget.exe pack $nuspecFilePath -o $buildOutputDir -version $packageVersion
 }

--- a/src/LibLog.Tests/LibLog.Tests.csproj
+++ b/src/LibLog.Tests/LibLog.Tests.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{543C177D-4ED3-45C2-BAC8-6A4E89D802BA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>YourRootNamespace.Logging</RootNamespace>
+    <RootNamespace>LibLog.Logging</RootNamespace>
     <AssemblyName>LibLog.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/LibLog.Tests/LibLog.Tests.csproj
+++ b/src/LibLog.Tests/LibLog.Tests.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{543C177D-4ED3-45C2-BAC8-6A4E89D802BA}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LibLog.Logging</RootNamespace>
+    <RootNamespace>YourRootNamespace.Logging</RootNamespace>
     <AssemblyName>LibLog.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/LibLog.Tests/LogProviderTests.cs
+++ b/src/LibLog.Tests/LogProviderTests.cs
@@ -1,12 +1,13 @@
-﻿namespace YourRootNamespace.Logging
+﻿namespace LibLog.Logging
 {
     using FluentAssertions;
-    using YourRootNamespace.Logging.LogProviders;
     using System;
     using NLog;
     using NLog.Config;
     using NLog.Targets;
     using Xunit;
+    using YourRootNamespace.Logging;
+    using YourRootNamespace.Logging.LogProviders;
 
     public class LogProviderTests : IDisposable
     {

--- a/src/LibLog.Tests/LogProviderTests.cs
+++ b/src/LibLog.Tests/LogProviderTests.cs
@@ -1,7 +1,7 @@
-﻿namespace LibLog.Logging
+﻿namespace YourRootNamespace.Logging
 {
     using FluentAssertions;
-    using LibLog.Logging.LogProviders;
+    using YourRootNamespace.Logging.LogProviders;
     using System;
     using NLog;
     using NLog.Config;

--- a/src/LibLog.Tests/LogProviders/ColouredConsoleProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/ColouredConsoleProviderLoggingTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LibLog.Logging.LogProviders
+﻿namespace YourRootNamespace.Logging.LogProviders
 {
     using System;
     using System.IO;

--- a/src/LibLog.Tests/LogProviders/ColouredConsoleProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/ColouredConsoleProviderLoggingTests.cs
@@ -1,10 +1,12 @@
-﻿namespace YourRootNamespace.Logging.LogProviders
+﻿namespace LibLog.Logging.LogProviders
 {
     using System;
     using System.IO;
     using FluentAssertions;
     using Xunit;
     using Xunit.Extensions;
+    using YourRootNamespace.Logging;
+    using YourRootNamespace.Logging.LogProviders;
 
     public class ColouredConsoleProviderLoggingTests : IDisposable
     {

--- a/src/LibLog.Tests/LogProviders/EntLibLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/EntLibLogProviderLoggingTests.cs
@@ -1,4 +1,4 @@
-﻿namespace YourRootNamespace.Logging.LogProviders
+﻿namespace LibLog.Logging.LogProviders
 {
     using System;
     using System.Collections.Generic;
@@ -11,6 +11,8 @@
     using Microsoft.Practices.ServiceLocation;
     using Xunit;
     using Xunit.Extensions;
+    using YourRootNamespace.Logging;
+    using YourRootNamespace.Logging.LogProviders;
     using LogLevel = YourRootNamespace.Logging.LogLevel;
 
     public class EntLibLogProviderLoggingTests : IDisposable

--- a/src/LibLog.Tests/LogProviders/EntLibLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/EntLibLogProviderLoggingTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LibLog.Logging.LogProviders
+﻿namespace YourRootNamespace.Logging.LogProviders
 {
     using System;
     using System.Collections.Generic;
@@ -11,7 +11,7 @@
     using Microsoft.Practices.ServiceLocation;
     using Xunit;
     using Xunit.Extensions;
-    using LogLevel = LibLog.Logging.LogLevel;
+    using LogLevel = YourRootNamespace.Logging.LogLevel;
 
     public class EntLibLogProviderLoggingTests : IDisposable
     {

--- a/src/LibLog.Tests/LogProviders/Log4NetLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/Log4NetLogProviderLoggingTests.cs
@@ -1,4 +1,4 @@
-﻿namespace YourRootNamespace.Logging.LogProviders
+﻿namespace LibLog.Logging.LogProviders
 {
     using System;
     using System.Linq;
@@ -9,6 +9,8 @@
     using log4net.Core;
     using Xunit;
     using Xunit.Extensions;
+    using YourRootNamespace.Logging;
+    using YourRootNamespace.Logging.LogProviders;
     using ILog = YourRootNamespace.Logging.ILog;
 
     public class Log4NetLogProviderLoggingTests : IDisposable

--- a/src/LibLog.Tests/LogProviders/Log4NetLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/Log4NetLogProviderLoggingTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LibLog.Logging.LogProviders
+﻿namespace YourRootNamespace.Logging.LogProviders
 {
     using System;
     using System.Linq;
@@ -9,7 +9,7 @@
     using log4net.Core;
     using Xunit;
     using Xunit.Extensions;
-    using ILog = LibLog.Logging.ILog;
+    using ILog = YourRootNamespace.Logging.ILog;
 
     public class Log4NetLogProviderLoggingTests : IDisposable
     {

--- a/src/LibLog.Tests/LogProviders/LogExtensons.cs
+++ b/src/LibLog.Tests/LogProviders/LogExtensons.cs
@@ -1,7 +1,8 @@
-namespace YourRootNamespace.Logging.LogProviders
+namespace LibLog.Logging.LogProviders
 {
     using System;
     using FluentAssertions;
+    using YourRootNamespace.Logging;
 
     internal static class LogExtensons
     {

--- a/src/LibLog.Tests/LogProviders/LogExtensons.cs
+++ b/src/LibLog.Tests/LogProviders/LogExtensons.cs
@@ -1,4 +1,4 @@
-namespace LibLog.Logging.LogProviders
+namespace YourRootNamespace.Logging.LogProviders
 {
     using System;
     using FluentAssertions;

--- a/src/LibLog.Tests/LogProviders/LoupeLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/LoupeLogProviderLoggingTests.cs
@@ -1,11 +1,11 @@
-﻿namespace LibLog.Logging.LogProviders
+﻿namespace YourRootNamespace.Logging.LogProviders
 {
     using System;
     using System.Runtime.CompilerServices;
     using Gibraltar.Agent;
     using Xunit;
     using Xunit.Extensions;
-    using ILog = LibLog.Logging.ILog;
+    using ILog = YourRootNamespace.Logging.ILog;
 
     public class LoupeProviderLoggingTests : IDisposable
     {

--- a/src/LibLog.Tests/LogProviders/LoupeLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/LoupeLogProviderLoggingTests.cs
@@ -1,10 +1,12 @@
-﻿namespace YourRootNamespace.Logging.LogProviders
+﻿namespace LibLog.Logging.LogProviders
 {
     using System;
     using System.Runtime.CompilerServices;
     using Gibraltar.Agent;
     using Xunit;
     using Xunit.Extensions;
+    using YourRootNamespace.Logging;
+    using YourRootNamespace.Logging.LogProviders;
     using ILog = YourRootNamespace.Logging.ILog;
 
     public class LoupeProviderLoggingTests : IDisposable

--- a/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LibLog.Logging.LogProviders
+﻿namespace YourRootNamespace.Logging.LogProviders
 {
     using System;
     using FluentAssertions;
@@ -7,7 +7,7 @@
     using NLog.Targets;
     using Xunit;
     using Xunit.Extensions;
-    using LogLevel = LibLog.Logging.LogLevel;
+    using LogLevel = YourRootNamespace.Logging.LogLevel;
 
     public class NLogLogProviderLoggingTests : IDisposable
     {

--- a/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
@@ -1,4 +1,4 @@
-﻿namespace YourRootNamespace.Logging.LogProviders
+﻿namespace LibLog.Logging.LogProviders
 {
     using System;
     using FluentAssertions;
@@ -7,6 +7,8 @@
     using NLog.Targets;
     using Xunit;
     using Xunit.Extensions;
+    using YourRootNamespace.Logging;
+    using YourRootNamespace.Logging.LogProviders;
     using LogLevel = YourRootNamespace.Logging.LogLevel;
 
     public class NLogLogProviderLoggingTests : IDisposable

--- a/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
@@ -1,4 +1,4 @@
-﻿namespace YourRootNamespace.Logging.LogProviders
+﻿namespace LibLog.Logging.LogProviders
 {
     using System;
     using System.Collections.Generic;
@@ -10,6 +10,8 @@
     using Serilog.Events;
     using Xunit;
     using Xunit.Extensions;
+    using YourRootNamespace.Logging;
+    using YourRootNamespace.Logging.LogProviders;
     using LogLevel = YourRootNamespace.Logging.LogLevel;
 
     public class SerilogLogProviderLoggingTests : IDisposable

--- a/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LibLog.Logging.LogProviders
+﻿namespace YourRootNamespace.Logging.LogProviders
 {
     using System;
     using System.Collections.Generic;
@@ -10,7 +10,7 @@
     using Serilog.Events;
     using Xunit;
     using Xunit.Extensions;
-    using LogLevel = LibLog.Logging.LogLevel;
+    using LogLevel = YourRootNamespace.Logging.LogLevel;
 
     public class SerilogLogProviderLoggingTests : IDisposable
     {

--- a/src/LibLog.Tests/LoggerExecutionWrapperTests.cs
+++ b/src/LibLog.Tests/LoggerExecutionWrapperTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LibLog.Logging
+﻿namespace YourRootNamespace.Logging
 {
     using System;
     using Xunit;

--- a/src/LibLog.Tests/LoggerExecutionWrapperTests.cs
+++ b/src/LibLog.Tests/LoggerExecutionWrapperTests.cs
@@ -1,7 +1,8 @@
-﻿namespace YourRootNamespace.Logging
+﻿namespace LibLog.Logging
 {
     using System;
     using Xunit;
+    using YourRootNamespace.Logging;
 
     public class LoggerExecutionWrapperTests
     {

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -1930,9 +1930,6 @@ namespace LibLog.Logging.LogProviders
         }
 
         public class ColouredConsoleLogger
-#if !LIBLOG_PROVIDERS_ONLY
-            : ILog
-#endif
         {
             private readonly string _name;
             private readonly Action<string> _write;

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -38,19 +38,19 @@
 
 #pragma warning disable 1591
 
-// If you copied this file manually, you need to change this namespace so not to clash with other libraries
+// If you copied this file manually, you need to change all "YourRootNameSpace" so not to clash with other libraries
 // that use LibLog
 #if LIBLOG_PROVIDERS_ONLY
-namespace LibLog.LibLog
+namespace YourRootNamespace.LibLog
 #else
-namespace LibLog.Logging
+namespace YourRootNamespace.Logging
 #endif
 {
     using System.Collections.Generic;
 #if LIBLOG_PROVIDERS_ONLY
-    using global::LibLog.LibLog.LogProviders;
+    using YourRootNamespace.LibLog.LogProviders;
 #else
-    using global::LibLog.Logging.LogProviders;
+    using YourRootNamespace.Logging.LogProviders;
 #endif
     using System;
 #if !LIBLOG_PROVIDERS_ONLY
@@ -708,9 +708,9 @@ namespace LibLog.Logging
 }
 
 #if LIBLOG_PROVIDERS_ONLY
-namespace LibLog.LibLog.LogProviders
+namespace YourRootNamespace.LibLog.LogProviders
 #else
-namespace LibLog.Logging.LogProviders
+namespace YourRootNamespace.Logging.LogProviders
 #endif
 {
     using System;

--- a/src/LibLog/LibLog.csproj
+++ b/src/LibLog/LibLog.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{B94A94E1-3C80-40CC-A79A-244446B3F75A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LibLog.Logging</RootNamespace>
+    <RootNamespace>YourRootNamespace.Logging</RootNamespace>
     <AssemblyName>LibLog</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/LibLog/LibLogPCL.csproj
+++ b/src/LibLog/LibLogPCL.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{9F9D65C4-E18A-4A20-9A51-AA8EB1822A60}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>YourRootNamespace.LibLog</RootNamespace>
+    <RootNamespace>YourRootNamespace.Logging</RootNamespace>
     <AssemblyName>LibLogPCL</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>

--- a/src/LibLog/LibLogPCL.csproj
+++ b/src/LibLog/LibLogPCL.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{9F9D65C4-E18A-4A20-9A51-AA8EB1822A60}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LibLogPCL</RootNamespace>
+    <RootNamespace>YourRootNamespace.LibLog</RootNamespace>
     <AssemblyName>LibLogPCL</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
This is to make it **explicitly** clear that the root namespace should be changed if the user copy-pastes the code.

Normal circumstances, the namespace will change on package install.