### PR TITLE
Internalize ILog, it's not part of the 'Set' API

### DIFF
--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -113,7 +113,7 @@ namespace YourRootNamespace.Logging
 #else
     internal
 #endif
-    static class LogExtensions
+    static partial class LogExtensions
     {
         public static bool IsDebugEnabled(this ILog logger)
         {

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -69,7 +69,12 @@ namespace YourRootNamespace.Logging
     /// <summary>
     /// Simple interface that represent a logger.
     /// </summary>
-    public interface ILog
+#if LIBLOG_PUBLIC
+    public
+#else
+    internal
+#endif
+    interface ILog
     {
         /// <summary>
         /// Log a message the specified log level.


### PR DESCRIPTION
It is used on the 'Get' API, mostly because of extensions methods over the interface.

Also make LogExtensions partial.

Re- fixes #48.