### PR TITLE
Fixed the regular expression in LogMessageFormatter 

### DIFF
--- a/src/LibLog.Tests/LogProviders/EntLibLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/EntLibLogProviderLoggingTests.cs
@@ -104,7 +104,22 @@
             Target.Logs[0].Message.Should().Be("m replaced" + Environment.NewLine + exception);
             Target.Logs[0].Severity.Should().Be(severity);
         }
+        [Theory]
+        [InlineData(LogLevel.Debug, TraceEventType.Verbose)]
+        [InlineData(LogLevel.Error, TraceEventType.Error)]
+        [InlineData(LogLevel.Fatal, TraceEventType.Critical)]
+        [InlineData(LogLevel.Info, TraceEventType.Information)]
+        [InlineData(LogLevel.Trace, TraceEventType.Verbose)]
+        [InlineData(LogLevel.Warn, TraceEventType.Warning)]
+        public void Should_be_able_to_log_message_and_exception_with_formatparams_modifiers(LogLevel logLevel, TraceEventType severity)
+        {
+            var exception = new Exception("e");
 
+            Sut.Log(logLevel, () => "m {@abc}", exception, "replaced");
+
+            Target.Logs[0].Message.Should().Be("m replaced" + Environment.NewLine + exception);
+            Target.Logs[0].Severity.Should().Be(severity);
+        }
         [Fact]
         public void Can_check_is_log_level_enabled()
         {

--- a/src/LibLog.Tests/LogProviders/Log4NetLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/Log4NetLogProviderLoggingTests.cs
@@ -87,6 +87,19 @@
 
             GetSingleMessage().Should().Be(messagePrefix + "|m replaced|e");
         }
+        [Theory]
+        [InlineData(LogLevel.Debug, "DEBUG")]
+        [InlineData(LogLevel.Error, "ERROR")]
+        [InlineData(LogLevel.Fatal, "FATAL")]
+        [InlineData(LogLevel.Info, "INFO")]
+        [InlineData(LogLevel.Trace, "DEBUG")] //Trace messages in log4net are rendered as Debug
+        [InlineData(LogLevel.Warn, "WARN")]
+        public void Should_be_able_to_log_message_and_exception_with_formatParams_modifiers(LogLevel logLevel, string messagePrefix)
+        {
+            _sut.Log(logLevel, () => "m {@abc}", new Exception("e"), "replaced");
+
+            GetSingleMessage().Should().Be(messagePrefix + "|m replaced|e");
+        }
 
         [Fact]
         public void Can_check_is_log_level_enabled()

--- a/src/LibLog.Tests/LogProviders/LoupeLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/LoupeLogProviderLoggingTests.cs
@@ -75,6 +75,18 @@
         {
             _sut.Log(logLevel, () => messagePrefix + " log message {abc} with exception", new Exception("e"), "replaced");
         }
+        [Theory]
+        [InlineData(LogLevel.Debug, "DEBUG")]
+        [InlineData(LogLevel.Error, "ERROR")]
+        [InlineData(LogLevel.Fatal, "CRITICAL")] //Fatal messages in Loupe are rendered as Critical
+        [InlineData(LogLevel.Info, "INFO")]
+        [InlineData(LogLevel.Trace, "DEBUG")] //Trace messages in Loupe are rendered as Debug
+        [InlineData(LogLevel.Warn, "WARN")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Should_be_able_to_log_message_and_exception_with_formatparams_modifiers(LogLevel logLevel, string messagePrefix)
+        {
+            _sut.Log(logLevel, () => messagePrefix + " log message {@abc} with exception", new Exception("e"), "replaced");
+        }
 
         [Fact]
         public void Can_check_is_log_level_enabled()

--- a/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
@@ -91,7 +91,19 @@
 
             _target.Logs[0].Should().Be(messagePrefix + "|||m replaced|e");
         }
+        [Theory]
+        [InlineData(LogLevel.Debug, "DEBUG")]
+        [InlineData(LogLevel.Error, "ERROR")]
+        [InlineData(LogLevel.Fatal, "FATAL")]
+        [InlineData(LogLevel.Info, "INFO")]
+        [InlineData(LogLevel.Trace, "TRACE")]
+        [InlineData(LogLevel.Warn, "WARN")]
+        public void Should_be_able_to_log_message_and_exception_with_format_parameters_modifiers(LogLevel logLevel, string messagePrefix)
+        {
+            _sut.Log(logLevel, () => "m {@abc}", new Exception("e"), new[] { "replaced" });
 
+            _target.Logs[0].Should().Be(messagePrefix + "|||m replaced|e");
+        }
         [Fact]
         public void Can_check_is_log_level_enabled()
         {

--- a/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
@@ -158,6 +158,15 @@
             _logEvent.Properties.Keys.Should().Contain("data");
             _logEvent.Properties["data"].ToString().Should().Be("\"log\"");
         }
+        [Fact]
+        public void Can_log_structured_serialized_message()
+        {
+            _sut.InfoFormat("Structured {@data} message", new{ Log="log",Count="1"});
+            _logEvent.RenderMessage().Should().Be("Structured { Log: \"log\", Count: \"1\" } message");
+            _logEvent.Properties.Keys.Should().Contain("data");
+            
+            
+        }
 
         public void Dispose()
         {

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -1813,7 +1813,7 @@ namespace YourRootNamespace.Logging.LogProviders
 
     internal static class LogMessageFormatter
     {
-        private static readonly Regex Pattern = new Regex(@"\{\w{1,}\}");
+        private static readonly Regex Pattern = new Regex(@"\{@?\w{1,}\}");
 
         /// <summary>
         /// Some logging frameworks support structured logging, such as serilog. This will allow you to add names to structured data in a format string:


### PR DESCRIPTION
The regular expression was being used to SimulateStructuredLogging. The existing regex was not recognizing the @ modifier , used by serilog, that indicates that the parameter should be serialized.