### PR TITLE
Don't read the DisableLoggingEnvironmentVariable if already disabled.

### DIFF
--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -675,15 +675,14 @@ namespace YourRootNamespace.Logging
 
         public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters)
         {
-#if LIBLOG_PORTABLE
             if (_getIsDisabled())
             {
                 return false;
             }
-#else
+#if !LIBLOG_PORTABLE
             var envVar = Environment.GetEnvironmentVariable(LogProvider.DisableLoggingEnvironmentVariable);
 
-            if (_getIsDisabled() || (envVar != null && envVar.Equals("true", StringComparison.OrdinalIgnoreCase)))
+            if (envVar != null && envVar.Equals("true", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }


### PR DESCRIPTION
In the main Log method, we don't need to access the environment variable if _getIsDisabled() would have returned true. This will speed the non-logging if disabled elsewhere by not checking the environment. This also unifies the code for LIBLOG_PORTABLE as much as possible.