### PR TITLE
fixed missing namespace replacement

### DIFF
--- a/default.ps1
+++ b/default.ps1
@@ -34,9 +34,7 @@ task RunTests -depends Compile {
 
 task CreatePP {
     (Get-Content $srcDir\$projectName\$projectName.cs) | Foreach-Object {
-        $_ -replace 'namespace YourRootNamespace', 'namespace $rootnamespace$' `
-        -replace 'using YourRootNamespace', 'using $rootnamespace$' `
-        -replace 'Target = "YourRootNamespace.', 'Target = "$rootnamespace$.'
+        $_ -replace 'YourRootNamespace\.', '$rootnamespace$.'
         } | Set-Content $buildOutputDir\$projectName.cs.pp -Encoding UTF8
 }
 


### PR DESCRIPTION
I noticed that the second instance of `YourRootNamespace` wasn't being replaced in the [second code analysis suppression](https://github.com/damianh/LibLog/blob/0ad013fb9c27e76e0138c415c77d9216803fb946/src/LibLog/LibLog.cs#L44).

Rather than add a fourth replacement, I switched to a single replacement which also matches on the trailing `.` which is enough to exclude the [docs line](https://github.com/damianh/LibLog/blob/0ad013fb9c27e76e0138c415c77d9216803fb946/src/LibLog/LibLog.cs#L46) from the replacement.

connects to #89 