### PR TITLE
Return a no-op disposable when opening a nested/mapped diagnostic context and no logprovider has been set.

### DIFF
--- a/src/LibLog.Tests.NoLogFwkReferences/LibLog.Tests.NoLogFwkReferences.csproj
+++ b/src/LibLog.Tests.NoLogFwkReferences/LibLog.Tests.NoLogFwkReferences.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{71AF4769-AF1A-4913-A79D-08314EC06A63}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>LibLog</RootNamespace>
+    <AssemblyName>LibLog.Tests.NoLogFwkReferences</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="LibLogTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LibLog\LibLog.csproj">
+      <Project>{b94a94e1-3c80-40cc-a79a-244446b3f75a}</Project>
+      <Name>LibLog</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/LibLog.Tests.NoLogFwkReferences/LibLogTests.cs
+++ b/src/LibLog.Tests.NoLogFwkReferences/LibLogTests.cs
@@ -1,0 +1,23 @@
+﻿namespace LibLog
+{
+    using System;
+    using Xunit;
+    using YourRootNamespace.Logging;
+
+    public class LibLogTests
+    {
+        [Fact]
+        public void Can_open_nested_diagnostic_context()
+        {
+            using (LogProvider.OpenNestedContext("a"))
+            { }
+        }
+
+        [Fact]
+        public void Can_open_mapped_diagnostic_context()
+        {
+            using (LogProvider.OpenMappedContext("a", "b"))
+            { }
+        }
+    }
+}

--- a/src/LibLog.Tests.NoLogFwkReferences/Properties/AssemblyInfo.cs
+++ b/src/LibLog.Tests.NoLogFwkReferences/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyTitle("LibLog.Tests.NoLogFwkReferences")]
+[assembly: AssemblyDescription("")]

--- a/src/LibLog.Tests.NoLogFwkReferences/packages.config
+++ b/src/LibLog.Tests.NoLogFwkReferences/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="1.9.2" targetFramework="net451" />
+</packages>

--- a/src/LibLog.sln
+++ b/src/LibLog.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibLog", "LibLog\LibLog.csproj", "{B94A94E1-3C80-40CC-A79A-244446B3F75A}"
 EndProject
@@ -29,6 +29,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibLog.Example.ColoredConsoleLogProvider", "LibLog.Example.ColoredConsoleLogProvider\LibLog.Example.ColoredConsoleLogProvider.csproj", "{AE63060E-10DB-497E-B161-3C13FF865C7B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibLog.Tests.NLog4", "LibLog.Tests.NLog4\LibLog.Tests.NLog4.csproj", "{C51AC88E-BF39-4CF6-8461-9FD9E5492950}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibLog.Tests.NoLogFwkReferences", "LibLog.Tests.NoLogFwkReferences\LibLog.Tests.NoLogFwkReferences.csproj", "{71AF4769-AF1A-4913-A79D-08314EC06A63}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -76,6 +78,10 @@ Global
 		{C51AC88E-BF39-4CF6-8461-9FD9E5492950}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C51AC88E-BF39-4CF6-8461-9FD9E5492950}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C51AC88E-BF39-4CF6-8461-9FD9E5492950}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71AF4769-AF1A-4913-A79D-08314EC06A63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71AF4769-AF1A-4913-A79D-08314EC06A63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71AF4769-AF1A-4913-A79D-08314EC06A63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71AF4769-AF1A-4913-A79D-08314EC06A63}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -559,11 +559,9 @@ namespace YourRootNamespace.Logging
 #endif
         static IDisposable OpenNestedContext(string message)
         {
-            if(CurrentLogProvider == null)
-            {
-                throw new InvalidOperationException(NullLogProvider);
-            }
-            return CurrentLogProvider.OpenNestedContext(message);
+            return CurrentLogProvider == null 
+                ? new DisposableAction(() => {}) 
+                : CurrentLogProvider.OpenNestedContext(message);
         }
 
         /// <summary>
@@ -580,11 +578,9 @@ namespace YourRootNamespace.Logging
 #endif
         static IDisposable OpenMappedContext(string key, string value)
         {
-            if (CurrentLogProvider == null)
-            {
-                throw new InvalidOperationException(NullLogProvider);
-            }
-            return CurrentLogProvider.OpenMappedContext(key, value);
+            return CurrentLogProvider == null 
+                ? new DisposableAction(() => { }) 
+                : CurrentLogProvider.OpenMappedContext(key, value);
         }
 #endif
 

--- a/src/LibLog/Properties/AssemblyInfo.cs
+++ b/src/LibLog/Properties/AssemblyInfo.cs
@@ -4,5 +4,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("LibLog")]
 [assembly: AssemblyDescription("")]
 [assembly: InternalsVisibleTo("LibLog.Tests")]
+[assembly: InternalsVisibleTo("LibLog.Tests.NoLogFwkReferences")]
 [assembly: InternalsVisibleTo("LibLogPCL.Tests")]
 [assembly: InternalsVisibleTo("LibLog.Tests.NLog4")]


### PR DESCRIPTION
Fixes #91 