### PR TITLE
SourceContext not outputing correctly in Serilog logger

### DIFF
--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -1531,7 +1531,7 @@ namespace YourRootNamespace.Logging.LogProviders
                 valueParam,
                 destructureObjectsParam)
                 .Compile();
-            return name => func("Name", name, false);
+            return name => func("SourceContext", name, false);
         }
 
         internal class SerilogLogger


### PR DESCRIPTION
Hi Mr Hickey,

As a proposed fix for #40 I would like to use [SourceContext](https://github.com/serilog/serilog/wiki/Writing-Log-Events#source-contexts) as the key when calling Serilog's ForContext().

This change brings LibLog in line with how Serilog's other overloads of ForContext() behave when [given a type](https://github.com/serilog/serilog/blob/d97f2b4f6fbd2afe42f3ccebfeef1e431eda239b/src/Serilog/Core/Pipeline/Logger.cs#L97).

In the Serilog library, this constant is defined in [Serilog.Core.Constants.SourceContextPropertyName ](https://github.com/serilog/serilog/blob/d97f2b4f6fbd2afe42f3ccebfeef1e431eda239b/src/Serilog/Core/Constants.cs#L27).

Thanks for your consideration!
Ben Brandt