### PR TITLE
Fix structured log replacement

### DIFF
--- a/src/LibLog.Tests.NLog4/LibLog.Tests.NLog4.csproj
+++ b/src/LibLog.Tests.NLog4/LibLog.Tests.NLog4.csproj
@@ -79,6 +79,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/LibLog.Tests.NoLogFwkReferences/LibLog.Tests.NoLogFwkReferences.csproj
+++ b/src/LibLog.Tests.NoLogFwkReferences/LibLog.Tests.NoLogFwkReferences.csproj
@@ -62,6 +62,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/LibLog.Tests/LibLog.Tests.csproj
+++ b/src/LibLog.Tests/LibLog.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -15,6 +16,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -130,6 +133,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="LoggerExecutionWrapperTests.cs" />
+    <Compile Include="LogMessageFormatterTests.cs" />
     <Compile Include="LogProviders\LoupeLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\Log4NetLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\EntLibLogProviderLoggingTests.cs" />
@@ -153,6 +157,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/LibLog.Tests/LogMessageFormatterTests.cs
+++ b/src/LibLog.Tests/LogMessageFormatterTests.cs
@@ -1,0 +1,31 @@
+﻿namespace LibLog.Logging
+{
+    using System;
+    using Shouldly;
+    using Xunit;
+    using YourRootNamespace.Logging;
+    using YourRootNamespace.Logging.LogProviders;
+
+    public class LogMessageFormatterTests
+    {
+        [Fact]
+        public void When_arguments_are_unique_and_not_escaped_Then_should_replace_them()
+        {
+            Func<string> messageBuilder = () => "This is an {argument1} and this an {argument2}.";
+
+            var formattedMessage = LogMessageFormatter.SimulateStructuredLogging(messageBuilder, new object[] { "arg0", "arg1" })();
+
+            formattedMessage.ShouldBe("This is an arg0 and this an arg1.");
+        }
+
+        [Fact]
+        public void When_arguments_are_escaped_Then_should_not_replace_them()
+        {
+            Func<string> messageBuilder = () => "This is an {argument} and this an {{escaped_argument}}.";
+
+            var formattedMessage = LogMessageFormatter.SimulateStructuredLogging(messageBuilder, new object[] { "arg0", "arg1" })();
+
+            formattedMessage.ShouldBe("This is an arg0 and this an {escaped_argument}.");
+        }
+    }
+}

--- a/src/LibLog.Tests/LogMessageFormatterTests.cs
+++ b/src/LibLog.Tests/LogMessageFormatterTests.cs
@@ -40,5 +40,17 @@
             formattedMessage.ShouldBe(
                 string.Format(CultureInfo.InvariantCulture, "Formatted {0:yyyy-MM-dd} and not formatted {1}.", date, date));
         }
+
+        [Fact]
+        public void When_argument_is_multiple_time_Then_should_be_replaced_with_same_value()
+        {
+            var date = DateTime.Today;
+            Func<string> messageBuilder = () => "{date:yyyy-MM-dd} {argument1} {date:yyyy}";
+
+            var formattedMessage = LogMessageFormatter.SimulateStructuredLogging(messageBuilder, new object[] { date, "arg0" })();
+
+            formattedMessage.ShouldBe(
+                string.Format(CultureInfo.InvariantCulture, "{0:yyyy-MM-dd} {1} {0:yyyy}", date, "arg0"));
+        }
     }
 }

--- a/src/LibLog.Tests/LogMessageFormatterTests.cs
+++ b/src/LibLog.Tests/LogMessageFormatterTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace LibLog.Logging
 {
     using System;
+    using System.Globalization;
     using Shouldly;
     using Xunit;
     using YourRootNamespace.Logging;
@@ -11,11 +12,11 @@
         [Fact]
         public void When_arguments_are_unique_and_not_escaped_Then_should_replace_them()
         {
-            Func<string> messageBuilder = () => "This is an {argument1} and this an {argument2}.";
+            Func<string> messageBuilder = () => "This is an {1argument} and this another {argument2} and a last one {2}.";
 
-            var formattedMessage = LogMessageFormatter.SimulateStructuredLogging(messageBuilder, new object[] { "arg0", "arg1" })();
+            var formattedMessage = LogMessageFormatter.SimulateStructuredLogging(messageBuilder, new object[] { "arg0", "arg1", "arg2" })();
 
-            formattedMessage.ShouldBe("This is an arg0 and this an arg1.");
+            formattedMessage.ShouldBe("This is an arg0 and this another arg1 and a last one arg2.");
         }
 
         [Fact]
@@ -26,6 +27,18 @@
             var formattedMessage = LogMessageFormatter.SimulateStructuredLogging(messageBuilder, new object[] { "arg0", "arg1" })();
 
             formattedMessage.ShouldBe("This is an arg0 and this an {escaped_argument}.");
+        }
+
+        [Fact]
+        public void When_argument_has_format_Then_should_preserve_format()
+        {
+            var date = DateTime.Today;
+            Func<string> messageBuilder = () => "Formatted {date1:yyyy-MM-dd} and not formatted {date2}.";
+
+            var formattedMessage = LogMessageFormatter.SimulateStructuredLogging(messageBuilder, new object[] { date, date })();
+
+            formattedMessage.ShouldBe(
+                string.Format(CultureInfo.InvariantCulture, "Formatted {0:yyyy-MM-dd} and not formatted {1}.", date, date));
         }
     }
 }

--- a/src/LibLog.Tests/app.config
+++ b/src/LibLog.Tests/app.config
@@ -14,19 +14,28 @@
       <section name="properties" type="System.Configuration.NameValueSectionHandler" />
     </sectionGroup>
   </configSections>
+
+  <appSettings>
+    <add key="xunit.parallelizeAssembly" value="true"/>
+    <add key="xunit.methodDisplay" value="method"/>
+  </appSettings>
   
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
   
-  
-  
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup><gibraltar>
+  <gibraltar>
     <!-- Here is where all of the Gibraltar configuration sections can be added.
-For information on config options and common scenarios see
-http://www.gibraltarsoftware.com/Support/Loupe/Documentation/WebFrame.html#DevelopersReference_AgentConfiguration_CommonScenarios.html
+         For information on config options and common scenarios see
+         http://www.gibraltarsoftware.com/Support/Loupe/Documentation/WebFrame.html#DevelopersReference_AgentConfiguration_CommonScenarios.html
     -->
-  </gibraltar><system.diagnostics>
+  </gibraltar>
+  
+  <system.diagnostics>
     <trace>
       <listeners>
         <add name="gibraltar" type="Gibraltar.Agent.LogListener, Gibraltar.Agent" />
       </listeners>
     </trace>
-  </system.diagnostics></configuration>
+  </system.diagnostics>
+</configuration>

--- a/src/LibLog.Tests/packages.LibLog.Tests.config
+++ b/src/LibLog.Tests/packages.LibLog.Tests.config
@@ -19,4 +19,5 @@
   <package id="xunit.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -1853,7 +1853,7 @@ namespace YourRootNamespace.Logging.LogProviders
 #if LIBLOG_PORTABLE
         private static readonly Regex Pattern = new Regex(@"(?<!{){@?(?<arg>[^\d{][^ }]*)}");
 #else
-        private static readonly Regex Pattern = new Regex(@"(?<!{){@?(?<arg>[^ {}]+)}", RegexOptions.Compiled);
+        private static readonly Regex Pattern = new Regex(@"(?<!{){@?(?<arg>[^ :{}]+)(?<format>:[^}]+)?}", RegexOptions.Compiled);
 #endif
 
         /// <summary>
@@ -1879,11 +1879,13 @@ namespace YourRootNamespace.Logging.LogProviders
                 int argumentIndex = 0;
                 foreach (Match match in Pattern.Matches(targetMessage))
                 {
+                    var arg = match.Groups["arg"].Value;
+
                     int notUsed;
-                    if (!int.TryParse(match.Value.Substring(1, match.Value.Length -2), out notUsed))
+                    if (!int.TryParse(arg, out notUsed))
                     {
                         targetMessage = ReplaceFirst(targetMessage, match.Value,
-                            "{" + argumentIndex++ + "}");
+                            "{" + argumentIndex++ + match.Groups["format"].Value + "}");
                     }
                 }
                 try

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -1876,7 +1876,8 @@ namespace YourRootNamespace.Logging.LogProviders
             return () =>
             {
                 string targetMessage = messageBuilder();
-                int argumentIndex = 0;
+                List<string> processedArguments = new List<string>();
+
                 foreach (Match match in Pattern.Matches(targetMessage))
                 {
                     var arg = match.Groups["arg"].Value;
@@ -1884,8 +1885,15 @@ namespace YourRootNamespace.Logging.LogProviders
                     int notUsed;
                     if (!int.TryParse(arg, out notUsed))
                     {
+                        int argumentIndex = processedArguments.IndexOf(arg);
+                        if (argumentIndex == -1)
+                        {
+                            argumentIndex = processedArguments.Count;
+                            processedArguments.Add(arg);
+                        }
+
                         targetMessage = ReplaceFirst(targetMessage, match.Value,
-                            "{" + argumentIndex++ + match.Groups["format"].Value + "}");
+                            "{" + argumentIndex + match.Groups["format"].Value + "}");
                     }
                 }
                 try

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -1849,7 +1849,12 @@ namespace YourRootNamespace.Logging.LogProviders
 
     internal static class LogMessageFormatter
     {
-        private static readonly Regex Pattern = new Regex(@"\{@?\w{1,}\}");
+        //private static readonly Regex Pattern = new Regex(@"\{@?\w{1,}\}");
+#if LIBLOG_PORTABLE
+        private static readonly Regex Pattern = new Regex(@"(?<!{){@?(?<arg>[^\d{][^ }]*)}");
+#else
+        private static readonly Regex Pattern = new Regex(@"(?<!{){@?(?<arg>[^ {}]+)}", RegexOptions.Compiled);
+#endif
 
         /// <summary>
         /// Some logging frameworks support structured logging, such as serilog. This will allow you to add names to structured data in a format string:


### PR DESCRIPTION
Fixes the following issues with simulating structured logging:
- escaped arguments are not preserved: `{{arg}}` should stay `{{arg}}`
- argument format is not supported: `{arg:yyyy-MM-dd}` should become `{0:yyyy-MM-dd}`)
- if argument is present multiple time, every occurrence has it's own index (`{arg} {arg}` should become `{0} {0}`)