### PR TITLE
Update LibLog.cs

### DIFF
--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -1489,7 +1489,8 @@ namespace YourRootNamespace.Logging.LogProviders
 
         private static Func<string, string, IDisposable> GetPushProperty()
         {
-            Type ndcContextType = Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx");
+            Type ndcContextType = Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx") ??
+                                  Type.GetType("Serilog.Context.LogContext, Serilog");
             MethodInfo pushPropertyMethod = ndcContextType.GetMethodPortable(
                 "PushProperty", 
                 typeof(string),


### PR DESCRIPTION
(issue #107)
Proposed fix to support Serilog 2.0 Context: when fullnexfx assembly is not present, look in serilog assembly itself).

