### PR TITLE
Enable formatted logging for log4net

### DIFF
--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -1251,7 +1251,9 @@ namespace YourRootNamespace.Logging.LogProviders
             private readonly object _levelError;
             private readonly object _levelFatal;
             private readonly Func<object, object, bool> _isEnabledForDelegate;
-            private readonly Action<object, Type, object, string, Exception> _logDelegate;
+            private readonly Action<object, object> _logDelegate;
+            private readonly Func<object, Type, object, string, Exception, object> _createLoggingEvent;
+            private Action<object, string, object> _loggingEventPropertySetter;
 
             [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ILogger")]
             internal Log4NetLogger(dynamic logger)
@@ -1277,38 +1279,123 @@ namespace YourRootNamespace.Logging.LogProviders
                 {
                     throw new InvalidOperationException("Type log4net.Core.ILogger, was not found.");
                 }
-                MethodInfo isEnabledMethodInfo = loggerType.GetMethodPortable("IsEnabledFor", logEventLevelType);
                 ParameterExpression instanceParam = Expression.Parameter(typeof(object));
                 UnaryExpression instanceCast = Expression.Convert(instanceParam, loggerType);
-                ParameterExpression callerStackBoundaryDeclaringTypeParam = Expression.Parameter(typeof(Type));
                 ParameterExpression levelParam = Expression.Parameter(typeof(object));
-                ParameterExpression messageParam = Expression.Parameter(typeof(string));
                 UnaryExpression levelCast = Expression.Convert(levelParam, logEventLevelType);
-                MethodCallExpression isEnabledMethodCall = Expression.Call(instanceCast, isEnabledMethodInfo, levelCast);
-                _isEnabledForDelegate = Expression.Lambda<Func<object, object, bool>>(isEnabledMethodCall, instanceParam, levelParam).Compile();
+                _isEnabledForDelegate = GetIsEnabledFor(loggerType, logEventLevelType, instanceCast, levelCast, instanceParam, levelParam);
 
-                // Action<object, object, string, Exception> Log =
-                // (logger, callerStackBoundaryDeclaringType, level, message, exception) => { ((ILogger)logger).Write(callerStackBoundaryDeclaringType, level, message, exception); }
+                Type loggingEventType = Type.GetType("log4net.Core.LoggingEvent, log4net");
+
+                _createLoggingEvent = GetCreateLoggingEvent(instanceParam, instanceCast, levelParam, levelCast, loggingEventType);
+
+                _logDelegate = GetLogDelegate(loggerType, loggingEventType, instanceCast, instanceParam);
+
+                _loggingEventPropertySetter = GetLoggingEventPropertySetter(loggingEventType);
+            }
+
+            private static Action<object, object> GetLogDelegate(Type loggerType, Type loggingEventType, UnaryExpression instanceCast,
+                                                 ParameterExpression instanceParam)
+            {
+                //Action<object, object, string, Exception> Log =
+                //(logger, callerStackBoundaryDeclaringType, level, message, exception) => { ((ILogger)logger).Log(new LoggingEvent(callerStackBoundaryDeclaringType, logger.Repository, logger.Name, level, message, exception)); }
                 MethodInfo writeExceptionMethodInfo = loggerType.GetMethodPortable("Log",
-                    typeof(Type),
-                    logEventLevelType,
-                    typeof(string),
-                    typeof(Exception));
-                ParameterExpression exceptionParam = Expression.Parameter(typeof(Exception));
+                                                                                   loggingEventType);
+
+                ParameterExpression loggingEventParameter =
+                    Expression.Parameter(typeof(object), "loggingEvent");
+
+                UnaryExpression loggingEventCasted =
+                    Expression.Convert(loggingEventParameter, loggingEventType);
+
                 var writeMethodExp = Expression.Call(
                     instanceCast,
                     writeExceptionMethodInfo,
-                    callerStackBoundaryDeclaringTypeParam,
-                    levelCast,
-                    messageParam,
-                    exceptionParam);
-                _logDelegate = Expression.Lambda<Action<object, Type, object, string, Exception>>(
-                    writeMethodExp,
-                    instanceParam,
-                    callerStackBoundaryDeclaringTypeParam,
-                    levelParam,
-                    messageParam,
-                    exceptionParam).Compile();
+                    loggingEventCasted);
+
+                var logDelegate = Expression.Lambda<Action<object, object>>(
+                                                writeMethodExp,
+                                                instanceParam,
+                                                loggingEventParameter).Compile();
+
+                return logDelegate;
+            }
+
+            private static Func<object, Type, object, string, Exception, object> GetCreateLoggingEvent(ParameterExpression instanceParam, UnaryExpression instanceCast, ParameterExpression levelParam, UnaryExpression levelCast, Type loggingEventType)
+            {
+                ParameterExpression callerStackBoundaryDeclaringTypeParam = Expression.Parameter(typeof(Type));
+                ParameterExpression messageParam = Expression.Parameter(typeof(string));
+                ParameterExpression exceptionParam = Expression.Parameter(typeof(Exception));
+
+                PropertyInfo repositoryProperty = loggingEventType.GetPropertyPortable("Repository");
+                PropertyInfo levelProperty = loggingEventType.GetPropertyPortable("Level");
+
+                ConstructorInfo loggingEventConstructor =
+                    loggingEventType.GetConstructorPortable(typeof(Type), repositoryProperty.PropertyType, typeof(string), levelProperty.PropertyType, typeof(object), typeof(Exception));
+
+                //Func<object, object, string, Exception, object> Log =
+                //(logger, callerStackBoundaryDeclaringType, level, message, exception) => new LoggingEvent(callerStackBoundaryDeclaringType, ((ILogger)logger).Repository, ((ILogger)logger).Name, (Level)level, message, exception); }
+                NewExpression newLoggingEventExpression =
+                    Expression.New(loggingEventConstructor,
+                                   callerStackBoundaryDeclaringTypeParam,
+                                   Expression.Property(instanceCast, "Repository"),
+                                   Expression.Property(instanceCast, "Name"),
+                                   levelCast,
+                                   messageParam,
+                                   exceptionParam);
+
+                var createLoggingEvent =
+                    Expression.Lambda<Func<object, Type, object, string, Exception, object>>(
+                                  newLoggingEventExpression,
+                                  instanceParam,
+                                  callerStackBoundaryDeclaringTypeParam,
+                                  levelParam,
+                                  messageParam,
+                                  exceptionParam)
+                              .Compile();
+
+                return createLoggingEvent;
+            }
+
+            private static Func<object, object, bool> GetIsEnabledFor(Type loggerType, Type logEventLevelType,
+                                                                      UnaryExpression instanceCast,
+                                                                      UnaryExpression levelCast,
+                                                                      ParameterExpression instanceParam,
+                                                                      ParameterExpression levelParam)
+            {
+                MethodInfo isEnabledMethodInfo = loggerType.GetMethodPortable("IsEnabledFor", logEventLevelType);
+                MethodCallExpression isEnabledMethodCall = Expression.Call(instanceCast, isEnabledMethodInfo, levelCast);
+
+                Func<object, object, bool> result =
+                    Expression.Lambda<Func<object, object, bool>>(isEnabledMethodCall, instanceParam, levelParam)
+                              .Compile();
+
+                return result;
+            }
+
+            private static Action<object, string, object> GetLoggingEventPropertySetter(Type loggingEventType)
+            {
+                ParameterExpression loggingEventParameter = Expression.Parameter(typeof(object), "loggingEvent");
+                ParameterExpression keyParameter = Expression.Parameter(typeof(string), "key");
+                ParameterExpression valueParameter = Expression.Parameter(typeof(object), "value");
+
+                PropertyInfo propertiesProperty = loggingEventType.GetPropertyPortable("Properties");
+                PropertyInfo item = propertiesProperty.PropertyType.GetPropertyPortable("Item");
+
+                // ((LoggingEvent)loggingEvent).Properties[key] = value;
+                var body =
+                    Expression.Assign(
+                        Expression.Property(
+                            Expression.Property(Expression.Convert(loggingEventParameter, loggingEventType),
+                                                propertiesProperty), item, keyParameter), valueParameter);
+
+                Action<object, string, object> result =
+                    Expression.Lambda<Action<object, string, object>>
+                              (body, loggingEventParameter, keyParameter,
+                               valueParameter)
+                              .Compile();
+
+                return result;
             }
 
             public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
@@ -1323,7 +1410,14 @@ namespace YourRootNamespace.Logging.LogProviders
                     return false;
                 }
 
-                messageFunc = LogMessageFormatter.SimulateStructuredLogging(messageFunc, formatParameters);
+                string message = messageFunc();
+
+                IEnumerable<string> patternMatches;
+
+                string formattedMessage =
+                    LogMessageFormatter.FormatStructuredMessage(message,
+                                                                formatParameters,
+                                                                out patternMatches);
 
                 // determine correct caller - this might change due to jit optimizations with method inlining
                 if (s_callerStackBoundaryType == null)
@@ -1349,8 +1443,26 @@ namespace YourRootNamespace.Logging.LogProviders
                 }
 
                 var translatedLevel = TranslateLevel(logLevel);
-                _logDelegate(_logger, s_callerStackBoundaryType, translatedLevel, messageFunc(), exception);
+
+                object loggingEvent = _createLoggingEvent(_logger, s_callerStackBoundaryType, translatedLevel, formattedMessage, exception);
+
+                PopulateProperties(loggingEvent, patternMatches, formatParameters);
+
+                _logDelegate(_logger, loggingEvent);
+
                 return true;
+            }
+
+            private void PopulateProperties(object loggingEvent, IEnumerable<string> patternMatches, object[] formatParameters)
+            {
+                IEnumerable<KeyValuePair<string, object>> keyToValue =
+                    patternMatches.Zip(formatParameters,
+                                       (key, value) => new KeyValuePair<string, object>(key, value));
+
+                foreach (KeyValuePair<string, object> keyValuePair in keyToValue)
+                {
+                    _loggingEventPropertySetter(loggingEvent, keyValuePair.Key, keyValuePair.Value);
+                }
             }
 
             private static bool IsInTypeHierarchy(Type currentType, Type checkType)
@@ -1999,34 +2111,8 @@ namespace YourRootNamespace.Logging.LogProviders
             return () =>
             {
                 string targetMessage = messageBuilder();
-                List<string> processedArguments = new List<string>();
-
-                foreach (Match match in Pattern.Matches(targetMessage))
-                {
-                    var arg = match.Groups["arg"].Value;
-
-                    int notUsed;
-                    if (!int.TryParse(arg, out notUsed))
-                    {
-                        int argumentIndex = processedArguments.IndexOf(arg);
-                        if (argumentIndex == -1)
-                        {
-                            argumentIndex = processedArguments.Count;
-                            processedArguments.Add(arg);
-                        }
-
-                        targetMessage = ReplaceFirst(targetMessage, match.Value,
-                            "{" + argumentIndex + match.Groups["format"].Value + "}");
-                    }
-                }
-                try
-                {
-                    return string.Format(CultureInfo.InvariantCulture, targetMessage, formatParameters);
-                }
-                catch (FormatException ex)
-                {
-                    throw new FormatException("The input string '" + targetMessage + "' could not be formatted using string.Format", ex);
-                }
+                IEnumerable<string> patternMatches;
+                return FormatStructuredMessage(targetMessage, formatParameters, out patternMatches);
             };
         }
 
@@ -2039,10 +2125,62 @@ namespace YourRootNamespace.Logging.LogProviders
             }
             return text.Substring(0, pos) + replace + text.Substring(pos + search.Length);
         }
+
+        public static string FormatStructuredMessage(string targetMessage, object[] formatParameters, out IEnumerable<string> patternMatches)
+        {
+            if (formatParameters.Length == 0)
+            {
+                patternMatches = Enumerable.Empty<string>();
+                return targetMessage;
+            }
+
+            List<string> processedArguments = new List<string>();
+            patternMatches = processedArguments;
+
+            foreach (Match match in Pattern.Matches(targetMessage))
+            {
+                var arg = match.Groups["arg"].Value;
+
+                int notUsed;
+                if (!int.TryParse(arg, out notUsed))
+                {
+                    int argumentIndex = processedArguments.IndexOf(arg);
+                    if (argumentIndex == -1)
+                    {
+                        argumentIndex = processedArguments.Count;
+                        processedArguments.Add(arg);
+                    }
+
+                    targetMessage = ReplaceFirst(targetMessage, match.Value,
+                        "{" + argumentIndex + match.Groups["format"].Value + "}");
+                }
+            }
+            try
+            {
+                return string.Format(CultureInfo.InvariantCulture, targetMessage, formatParameters);
+            }
+            catch (FormatException ex)
+            {
+                throw new FormatException("The input string '" + targetMessage + "' could not be formatted using string.Format", ex);
+            }
+        }
     }
 
     internal static class TypeExtensions
     {
+        internal static ConstructorInfo GetConstructorPortable(this Type type, params Type[] types)
+        {
+#if LIBLOG_PORTABLE
+            return type.GetTypeInfo().DeclaredConstructors.FirstOrDefault
+                       (constructor =>
+                            constructor.GetParameters()
+                                       .Select(parameter => parameter.ParameterType)
+                                       .SequenceEqual(types));
+#else
+            return type.GetConstructor(types);
+#endif
+        }
+
         internal static MethodInfo GetMethodPortable(this Type type, string name)
         {
 #if LIBLOG_PORTABLE


### PR DESCRIPTION
Currently when writing a structured logging message using log4net, it is simply formatted to a string and written to the log as a string. The user can't take advantage of the structured message containing named parameters.

This pull requests adds the specified named arguments to the Properties of LoggingEvent written to the log: Instead of calling the previously called Log overload of ILogger which that gets all arguments and creates a LoggingEvent - we create a LoggingEvent ourselves and call ILogger's Log overload which receives a LoggingEvent. Before calling it, we populate its Properties property with the structured data. In order to avoid computing the structured data twice, I refactored a bit the LogMessageFormatter and introduced a method there that returns the structured arguments as an out parameter.

Usage:
```csharp
Logger.InfoFormat("Hello {Place}!", "World");
```

Accessing property from configuration:
```xml
<appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
    <layout type="log4net.Layout.PatternLayout">
        <conversionPattern value="%property{Place} %date | %thread | %-5level | %logger | %message%newline" />
    </layout>
</appender>
```

(You simply access the property using the %property syntax)