### PR TITLE
Serilog 2.X support

### DIFF
--- a/src/LibLog.Example.Serilog/LibLog.Example.Serilog.csproj
+++ b/src/LibLog.Example.Serilog/LibLog.Example.Serilog.csproj
@@ -32,12 +32,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.4.204\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.2.1\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.4.204\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.Sinks.ColoredConsole, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.ColoredConsole.2.0.0\lib\net45\Serilog.Sinks.ColoredConsole.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/LibLog.Example.Serilog/packages.config
+++ b/src/LibLog.Example.Serilog/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="1.4.204" targetFramework="net45" />
+  <package id="Serilog" version="2.2.1" targetFramework="net45" />
+  <package id="Serilog.Sinks.ColoredConsole" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/src/LibLog.Tests.Serilog2/LibLog.Tests.Serilog2.csproj
+++ b/src/LibLog.Tests.Serilog2/LibLog.Tests.Serilog2.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C51AC88E-BF39-4CF6-8461-9FD9E5492950}</ProjectGuid>
+    <ProjectGuid>{6729DACD-2C0E-4A80-8C9B-51E3E811CFE8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LibLog.Logging.NLog4</RootNamespace>
-    <AssemblyName>LibLog.Tests.NLog4</AssemblyName>
+    <RootNamespace>LibLog.Tests.Serilog2</RootNamespace>
+    <AssemblyName>LibLog.Tests.Serilog2</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -20,7 +20,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,11 +28,18 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.0.0\lib\net45\NLog.dll</HintPath>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.2.1\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Console, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Console.2.1.0\lib\net45\Serilog.Sinks.Console.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Observable, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Observable.2.0.0\lib\net45\Serilog.Sinks.Observable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Shouldly, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
@@ -42,9 +48,20 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Xml" />
+    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -59,28 +76,21 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\LibLog.Tests\LogProviders\LogExtensions.cs">
-      <Link>LogExtensions.cs</Link>
-    </Compile>
-    <Compile Include="..\LibLog.Tests\LogProviders\NLogLogProviderLoggingTests.cs">
-      <Link>NLogLogProviderLoggingTests.cs</Link>
-    </Compile>
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="LogExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SerilogLogProviderLoggingTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LibLog\LibLog.csproj">
       <Project>{b94a94e1-3c80-40cc-a79a-244446b3f75a}</Project>
       <Name>LibLog</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/LibLog.Tests.Serilog2/LogExtensions.cs
+++ b/src/LibLog.Tests.Serilog2/LogExtensions.cs
@@ -4,7 +4,7 @@ namespace LibLog.Logging.LogProviders
     using Shouldly;
     using YourRootNamespace.Logging;
 
-    internal static class LogExtensons
+    internal static class LogExtensions
     {
         public static void AssertCanCheckLogLevelsEnabled(this ILog logger)
         {

--- a/src/LibLog.Tests.Serilog2/Properties/AssemblyInfo.cs
+++ b/src/LibLog.Tests.Serilog2/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿using System.Reflection;
+using Xunit;
+
+[assembly: AssemblyTitle("LibLog.Tests.Serilog2")]
+[assembly: AssemblyDescription("")]
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+

--- a/src/LibLog.Tests.Serilog2/SerilogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests.Serilog2/SerilogLogProviderLoggingTests.cs
@@ -1,0 +1,192 @@
+﻿namespace LibLog.Logging.LogProviders
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Runtime.Remoting.Messaging;
+    using Serilog;
+    using Serilog.Context;
+    using Serilog.Events;
+    using Shouldly;
+    using Xunit;
+    using YourRootNamespace.Logging;
+    using YourRootNamespace.Logging.LogProviders;
+    using LogLevel = YourRootNamespace.Logging.LogLevel;
+
+    public class SerilogLogProviderLoggingTests : IDisposable
+    {
+        private readonly ILog _sut;
+        private LogEvent _logEvent;
+        private readonly SerilogLogProvider _logProvider;
+        private readonly IEnumerable<LogLevel> _allLevels = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToList();
+        private readonly IDictionary<LogLevel, Predicate<ILog>> _checkIsEnabledFor = new Dictionary<LogLevel, Predicate<ILog>>
+        {
+            {LogLevel.Trace, log => log.IsTraceEnabled()},
+            {LogLevel.Debug, log => log.IsDebugEnabled()},
+            {LogLevel.Info, log => log.IsInfoEnabled()},
+            {LogLevel.Warn, log => log.IsWarnEnabled()},
+            {LogLevel.Error, log => log.IsErrorEnabled()},
+            {LogLevel.Fatal, log => log.IsFatalEnabled()},
+        };
+
+        public SerilogLogProviderLoggingTests()
+        {
+            var logger = new LoggerConfiguration()
+                .Enrich.FromLogContext()
+                .MinimumLevel.Is(LogEventLevel.Verbose)
+                .WriteTo.Observers(obs => obs.Subscribe(logEvent => _logEvent = logEvent))
+                .WriteTo.Console()
+                .CreateLogger();
+
+            Log.Logger = logger;
+            _logProvider = new SerilogLogProvider();
+            _sut = new LoggerExecutionWrapper(_logProvider.GetLogger("Test"));
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Debug, LogEventLevel.Debug)]
+        [InlineData(LogLevel.Error, LogEventLevel.Error)]
+        [InlineData(LogLevel.Fatal, LogEventLevel.Fatal)]
+        [InlineData(LogLevel.Info, LogEventLevel.Information)]
+        [InlineData(LogLevel.Trace, LogEventLevel.Verbose)]
+        [InlineData(LogLevel.Warn, LogEventLevel.Warning)]
+        public void Should_be_able_to_log_message(LogLevel logLevel, LogEventLevel logEventLevel)
+        {
+            _sut.Log(logLevel, () => "m");
+
+            _logEvent.Level.ShouldBe(logEventLevel);
+            _logEvent.RenderMessage().ShouldBe("m");
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Debug, LogEventLevel.Debug)]
+        [InlineData(LogLevel.Error, LogEventLevel.Error)]
+        [InlineData(LogLevel.Fatal, LogEventLevel.Fatal)]
+        [InlineData(LogLevel.Info, LogEventLevel.Information)]
+        [InlineData(LogLevel.Trace, LogEventLevel.Verbose)]
+        [InlineData(LogLevel.Warn, LogEventLevel.Warning)]
+        public void Should_be_able_to_log_message_with_param(LogLevel logLevel, LogEventLevel logEventLevel)
+        {
+            _sut.Log(logLevel, () => "m {0}", null, "param");
+
+            _logEvent.Level.ShouldBe(logEventLevel);
+            _logEvent.RenderMessage().ShouldBe("m \"param\"");
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Debug, LogEventLevel.Debug)]
+        [InlineData(LogLevel.Error, LogEventLevel.Error)]
+        [InlineData(LogLevel.Fatal, LogEventLevel.Fatal)]
+        [InlineData(LogLevel.Info, LogEventLevel.Information)]
+        [InlineData(LogLevel.Trace, LogEventLevel.Verbose)]
+        [InlineData(LogLevel.Warn, LogEventLevel.Warning)]
+        public void Should_be_able_to_log_message_and_exception(LogLevel logLevel, LogEventLevel logEventLevel)
+        {
+            var exception = new Exception("e");
+            _sut.Log(logLevel, () => "m", exception);
+
+            _logEvent.Level.ShouldBe(logEventLevel);
+            _logEvent.RenderMessage().ShouldBe("m");
+            _logEvent.Exception.ShouldBe(exception);
+        }
+
+        [Fact]
+        public void Can_check_is_log_level_enabled()
+        {
+            _sut.AssertCanCheckLogLevelsEnabled();
+        }
+
+        [Fact]
+        public void Can_open_nested_diagnostics_context()
+        {
+            using (_logProvider.OpenNestedContext("context"))
+            {
+                _sut.Info("m");
+
+                _logEvent.Properties.Keys.ShouldContain("NDC");
+                _logEvent.Properties["NDC"].ToString().ShouldBe("\"context\"");
+            }
+        }
+
+        [Fact]
+        public void Can_open_mapped_diagnostics_context()
+        {
+            using (_logProvider.OpenMappedContext("key", "value"))
+            {
+                _sut.Info("m");
+
+                _logEvent.Properties.Keys.ShouldContain("key");
+                _logEvent.Properties["key"].ToString().ShouldBe("\"value\"");
+            }
+        }
+
+        [Theory]
+        [InlineData(LogEventLevel.Verbose, new []{LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]
+        [InlineData(LogEventLevel.Debug, new []{LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]
+        [InlineData(LogEventLevel.Information, new[]{LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]
+        [InlineData(LogEventLevel.Warning, new[]{LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]
+        [InlineData(LogEventLevel.Error, new[]{LogLevel.Error, LogLevel.Fatal})]
+        [InlineData(LogEventLevel.Fatal, new []{LogLevel.Fatal})]
+        public void Should_enable_self_and_above_when_setup_with(LogEventLevel minimum, LogLevel[] expectedEnabledLevels)
+        {
+            AutoRollbackLoggerSetup(minimum,
+                log =>
+                {
+                    foreach (var expectedEnabled in expectedEnabledLevels)
+                    {
+                        _checkIsEnabledFor[expectedEnabled](log)
+                            .ShouldBeTrue();
+                           // "loglevel: '{0}' should be enabled when minimum (serilog) level is '{1}'", expectedEnabled, minimum);
+                    }
+
+                    foreach (var expectedDisabled in _allLevels.Except(expectedEnabledLevels))
+                    {
+                        _checkIsEnabledFor[expectedDisabled](log)
+                            .ShouldBeFalse();
+                        //"loglevel '{0}' should be diabled when minimum (serilog) level is '{1}'", expectedDisabled, minimum);
+                    }
+                });
+        }
+
+        [Fact]
+        public void Can_log_structured_message()
+        {
+            _sut.InfoFormat("Structured {data} message", "log");
+
+            _logEvent.RenderMessage().ShouldBe("Structured \"log\" message");
+            _logEvent.Properties.Keys.ShouldContain("data");
+            _logEvent.Properties["data"].ToString().ShouldBe("\"log\"");
+        }
+        [Fact]
+        public void Can_log_structured_serialized_message()
+        {
+            _sut.InfoFormat("Structured {@data} message", new{ Log="log",Count="1"});
+            _logEvent.RenderMessage().ShouldBe("Structured { Log: \"log\", Count: \"1\" } message");
+            _logEvent.Properties.Keys.ShouldContain("data");
+        }
+
+        public void Dispose()
+        {
+            // Workaround for SerializationException on LogContext when using xUnit.net
+            // https://github.com/serilog/serilog/issues/109#issuecomment-40256706
+            CallContext.FreeNamedDataSlot(typeof(LogContext).FullName);
+        }
+
+        private static void AutoRollbackLoggerSetup(LogEventLevel minimumLevel, Action<ILog> @do)
+        {
+            var originalLogger = Log.Logger;
+            try
+            {
+                Log.Logger = new LoggerConfiguration()
+                    .MinimumLevel.Is(minimumLevel)
+                    .CreateLogger();
+
+                @do(new LoggerExecutionWrapper(new SerilogLogProvider().GetLogger("Test")));
+            }
+            finally
+            {
+                Log.Logger = originalLogger;
+            }
+        }
+    }
+}

--- a/src/LibLog.Tests.Serilog2/packages.config
+++ b/src/LibLog.Tests.Serilog2/packages.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
+  <package id="Serilog" version="2.2.1" targetFramework="net45" />
+  <package id="Serilog.Sinks.Console" version="2.1.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.Observable" version="2.0.0" targetFramework="net45" />
+  <package id="Shouldly" version="2.6.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/src/LibLog.Tests/LibLog.Tests.csproj
+++ b/src/LibLog.Tests/LibLog.Tests.csproj
@@ -137,7 +137,7 @@
     <Compile Include="LogProviders\LoupeLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\Log4NetLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\EntLibLogProviderLoggingTests.cs" />
-    <Compile Include="LogProviders\LogExtensons.cs" />
+    <Compile Include="LogProviders\LogExtensions.cs" />
     <Compile Include="LogProviders\SerilogLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\NLogLogProviderLoggingTests.cs" />
     <Compile Include="LogProviderTests.cs" />

--- a/src/LibLog.Tests/LibLogPCL.Tests.csproj
+++ b/src/LibLog.Tests/LibLogPCL.Tests.csproj
@@ -130,10 +130,10 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="LoggerExecutionWrapperTests.cs" />
+    <Compile Include="LogProviders\LogExtensions.cs" />
     <Compile Include="LogProviders\LoupeLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\Log4NetLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\EntLibLogProviderLoggingTests.cs" />
-    <Compile Include="LogProviders\LogExtensons.cs" />
     <Compile Include="LogProviders\SerilogLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\NLogLogProviderLoggingTests.cs" />
     <Compile Include="LogProviderTests.cs" />

--- a/src/LibLog.Tests/LogProviders/LogExtensions.cs
+++ b/src/LibLog.Tests/LogProviders/LogExtensions.cs
@@ -1,0 +1,27 @@
+namespace LibLog.Logging.LogProviders
+{
+    using System;
+    using Shouldly;
+    using YourRootNamespace.Logging;
+
+    internal static class LogExtensions
+    {
+        public static void AssertCanCheckLogLevelsEnabled(this ILog logger)
+        {
+            var loglevelEnabledActions = new Action[]
+            {
+                () => logger.IsTraceEnabled(),
+                () => logger.IsDebugEnabled(),
+                () => logger.IsInfoEnabled(),
+                () => logger.IsWarnEnabled(),
+                () => logger.IsErrorEnabled(),
+                () => logger.IsFatalEnabled(),
+            };
+
+            foreach (var isLogLevelEnabled in loglevelEnabledActions)
+            {
+                isLogLevelEnabled.ShouldNotThrow();
+            }
+        }
+    }
+}

--- a/src/LibLog.sln
+++ b/src/LibLog.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibLog", "LibLog\LibLog.csproj", "{B94A94E1-3C80-40CC-A79A-244446B3F75A}"
 EndProject
@@ -31,6 +31,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibLog.Tests.NLog4", "LibLog.Tests.NLog4\LibLog.Tests.NLog4.csproj", "{C51AC88E-BF39-4CF6-8461-9FD9E5492950}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibLog.Tests.NoLogFwkReferences", "LibLog.Tests.NoLogFwkReferences\LibLog.Tests.NoLogFwkReferences.csproj", "{71AF4769-AF1A-4913-A79D-08314EC06A63}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibLog.Tests.Serilog2", "LibLog.Tests.Serilog2\LibLog.Tests.Serilog2.csproj", "{6729DACD-2C0E-4A80-8C9B-51E3E811CFE8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -82,6 +84,10 @@ Global
 		{71AF4769-AF1A-4913-A79D-08314EC06A63}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{71AF4769-AF1A-4913-A79D-08314EC06A63}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{71AF4769-AF1A-4913-A79D-08314EC06A63}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6729DACD-2C0E-4A80-8C9B-51E3E811CFE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6729DACD-2C0E-4A80-8C9B-51E3E811CFE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6729DACD-2C0E-4A80-8C9B-51E3E811CFE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6729DACD-2C0E-4A80-8C9B-51E3E811CFE8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -543,7 +543,7 @@ namespace YourRootNamespace.Logging
         static ILog GetLogger(string name)
         {
             ILogProvider logProvider = CurrentLogProvider ?? ResolveLogProvider();
-            return logProvider == null 
+            return logProvider == null
                 ? NoOpLogger.Instance
                 : (ILog)new LoggerExecutionWrapper(logProvider.GetLogger(name), () => IsDisabled);
         }
@@ -759,7 +759,7 @@ namespace YourRootNamespace.Logging.LogProviders
 
         protected LogProviderBase()
         {
-            _lazyOpenNdcMethod 
+            _lazyOpenNdcMethod
                 = new Lazy<OpenNdc>(GetOpenNdcMethod);
             _lazyOpenMdcMethod
                = new Lazy<OpenMdc>(GetOpenMdcMethod);
@@ -1607,7 +1607,7 @@ namespace YourRootNamespace.Logging.LogProviders
             Expression severityParameter, ParameterExpression logNameParameter)
         {
             var entryType = LogEntryType;
-            MemberInitExpression memberInit = Expression.MemberInit(Expression.New(entryType), 
+            MemberInitExpression memberInit = Expression.MemberInit(Expression.New(entryType),
                 Expression.Bind(entryType.GetPropertyPortable("Message"), message),
                 Expression.Bind(entryType.GetPropertyPortable("Severity"), severityParameter),
                 Expression.Bind(
@@ -1723,13 +1723,15 @@ namespace YourRootNamespace.Logging.LogProviders
 
         private static Func<string, string, IDisposable> GetPushProperty()
         {
-            Type ndcContextType = Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx") ??
-                                  Type.GetType("Serilog.Context.LogContext, Serilog");
+            Type ndcContextType = Type.GetType("Serilog.Context.LogContext, Serilog") ?? 
+                                  Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx");
+
             MethodInfo pushPropertyMethod = ndcContextType.GetMethodPortable(
                 "PushProperty", 
                 typeof(string),
                 typeof(object),
                 typeof(bool));
+
             ParameterExpression nameParam = Expression.Parameter(typeof(string), "name");
             ParameterExpression valueParam = Expression.Parameter(typeof(object), "value");
             ParameterExpression destructureObjectParam = Expression.Parameter(typeof(bool), "destructureObjects");

--- a/src/LibLog/Properties/AssemblyInfo.cs
+++ b/src/LibLog/Properties/AssemblyInfo.cs
@@ -7,3 +7,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("LibLog.Tests.NoLogFwkReferences")]
 [assembly: InternalsVisibleTo("LibLogPCL.Tests")]
 [assembly: InternalsVisibleTo("LibLog.Tests.NLog4")]
+[assembly: InternalsVisibleTo("LibLog.Tests.Serilog2")]


### PR DESCRIPTION
Serilog example updated to latest versions.
Fixed a typo with log extensions.
Using Serilog 2.2.1