### PR TITLE
    Add [ExcludeFromCodeCoverage] attribute

### DIFF
--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -121,6 +121,7 @@ namespace YourRootNamespace.Logging
     }
 
 #if !LIBLOG_PROVIDERS_ONLY
+    [ExcludeFromCodeCoverage]
 #if LIBLOG_PUBLIC
     public
 #else
@@ -414,6 +415,7 @@ namespace YourRootNamespace.Logging
     /// <summary>
     /// Provides a mechanism to create instances of <see cref="ILog" /> objects.
     /// </summary>
+    [ExcludeFromCodeCoverage]
 #if LIBLOG_PROVIDERS_ONLY
     internal
 #else
@@ -653,6 +655,7 @@ namespace YourRootNamespace.Logging
         }
 
 #if !LIBLOG_PROVIDERS_ONLY
+        [ExcludeFromCodeCoverage]
         internal class NoOpLogger : ILog
         {
             internal static readonly NoOpLogger Instance = new NoOpLogger();
@@ -666,6 +669,7 @@ namespace YourRootNamespace.Logging
     }
 
 #if !LIBLOG_PROVIDERS_ONLY
+    [ExcludeFromCodeCoverage]
     internal class LoggerExecutionWrapper : ILog
     {
         private readonly Logger _logger;
@@ -734,6 +738,7 @@ namespace YourRootNamespace.Logging.LogProviders
 #endif
     using System.Text.RegularExpressions;
 
+    [ExcludeFromCodeCoverage]
     internal abstract class LogProviderBase : ILogProvider
     {
         protected delegate IDisposable OpenNdc(string message);
@@ -774,6 +779,7 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+    [ExcludeFromCodeCoverage]
     internal class NLogLogProvider : LogProviderBase
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
@@ -855,6 +861,7 @@ namespace YourRootNamespace.Logging.LogProviders
             return Expression.Lambda<Func<string, object>>(methodCall, nameParam).Compile();
         }
 
+        [ExcludeFromCodeCoverage]
         internal class NLogLogger
         {
             private readonly dynamic _logger;
@@ -1117,6 +1124,7 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+    [ExcludeFromCodeCoverage]
     internal class Log4NetLogProvider : LogProviderBase
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
@@ -1225,6 +1233,7 @@ namespace YourRootNamespace.Logging.LogProviders
             return Expression.Lambda<Func<string, object>>(methodCall, nameParam).Compile();
         }
 
+        [ExcludeFromCodeCoverage]
         internal class Log4NetLogger
         {
             private readonly dynamic _logger;
@@ -1492,6 +1501,7 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+    [ExcludeFromCodeCoverage]
     internal class EntLibLogProvider : LogProviderBase
     {
         private const string TypeTemplate = "Microsoft.Practices.EnterpriseLibrary.Logging.{0}, Microsoft.Practices.EnterpriseLibrary.Logging";
@@ -1608,6 +1618,7 @@ namespace YourRootNamespace.Logging.LogProviders
             return memberInit;
         }
 
+        [ExcludeFromCodeCoverage]
         internal class EntLibLogger
         {
             private readonly string _loggerName;
@@ -1666,6 +1677,7 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+    [ExcludeFromCodeCoverage]
     internal class SerilogLogProvider : LogProviderBase
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
@@ -1761,6 +1773,7 @@ namespace YourRootNamespace.Logging.LogProviders
             return name => func("SourceContext", name, false);
         }
 
+        [ExcludeFromCodeCoverage]
         internal class SerilogLogger
         {
             private readonly object _logger;
@@ -1911,6 +1924,7 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+    [ExcludeFromCodeCoverage]
     internal class LoupeLogProvider : LogProviderBase
     {
         /// <summary>
@@ -1985,6 +1999,7 @@ namespace YourRootNamespace.Logging.LogProviders
             return callDelegate;
         }
 
+        [ExcludeFromCodeCoverage]
         internal class LoupeLogger
         {
             private const string LogSystem = "LibLog";
@@ -2043,6 +2058,7 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+    [ExcludeFromCodeCoverage]
     internal static class TraceEventTypeValues
     {
         internal static readonly Type Type;
@@ -2070,6 +2086,7 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+    [ExcludeFromCodeCoverage]
     internal static class LogMessageFormatter
     {
         //private static readonly Regex Pattern = new Regex(@"\{@?\w{1,}\}");
@@ -2154,6 +2171,7 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+    [ExcludeFromCodeCoverage]
     internal static class TypeExtensions
     {
         internal static ConstructorInfo GetConstructorPortable(this Type type, params Type[] types)
@@ -2243,6 +2261,7 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+    [ExcludeFromCodeCoverage]
     internal class DisposableAction : IDisposable
     {
         private readonly Action _onDispose;

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -121,7 +121,9 @@ namespace YourRootNamespace.Logging
     }
 
 #if !LIBLOG_PROVIDERS_ONLY
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
 #if LIBLOG_PUBLIC
     public
 #else
@@ -415,7 +417,9 @@ namespace YourRootNamespace.Logging
     /// <summary>
     /// Provides a mechanism to create instances of <see cref="ILog" /> objects.
     /// </summary>
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
 #if LIBLOG_PROVIDERS_ONLY
     internal
 #else
@@ -655,7 +659,9 @@ namespace YourRootNamespace.Logging
         }
 
 #if !LIBLOG_PROVIDERS_ONLY
+#if !LIBLOG_PORTABLE
         [ExcludeFromCodeCoverage]
+#endif
         internal class NoOpLogger : ILog
         {
             internal static readonly NoOpLogger Instance = new NoOpLogger();
@@ -669,7 +675,9 @@ namespace YourRootNamespace.Logging
     }
 
 #if !LIBLOG_PROVIDERS_ONLY
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
     internal class LoggerExecutionWrapper : ILog
     {
         private readonly Logger _logger;
@@ -738,7 +746,9 @@ namespace YourRootNamespace.Logging.LogProviders
 #endif
     using System.Text.RegularExpressions;
 
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
     internal abstract class LogProviderBase : ILogProvider
     {
         protected delegate IDisposable OpenNdc(string message);
@@ -779,7 +789,9 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
     internal class NLogLogProvider : LogProviderBase
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
@@ -861,7 +873,9 @@ namespace YourRootNamespace.Logging.LogProviders
             return Expression.Lambda<Func<string, object>>(methodCall, nameParam).Compile();
         }
 
+#if !LIBLOG_PORTABLE
         [ExcludeFromCodeCoverage]
+#endif
         internal class NLogLogger
         {
             private readonly dynamic _logger;
@@ -1124,7 +1138,9 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
     internal class Log4NetLogProvider : LogProviderBase
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
@@ -1233,7 +1249,9 @@ namespace YourRootNamespace.Logging.LogProviders
             return Expression.Lambda<Func<string, object>>(methodCall, nameParam).Compile();
         }
 
+#if !LIBLOG_PORTABLE
         [ExcludeFromCodeCoverage]
+#endif
         internal class Log4NetLogger
         {
             private readonly dynamic _logger;
@@ -1501,7 +1519,9 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
     internal class EntLibLogProvider : LogProviderBase
     {
         private const string TypeTemplate = "Microsoft.Practices.EnterpriseLibrary.Logging.{0}, Microsoft.Practices.EnterpriseLibrary.Logging";
@@ -1618,7 +1638,9 @@ namespace YourRootNamespace.Logging.LogProviders
             return memberInit;
         }
 
+#if !LIBLOG_PORTABLE
         [ExcludeFromCodeCoverage]
+#endif
         internal class EntLibLogger
         {
             private readonly string _loggerName;
@@ -1677,7 +1699,9 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
     internal class SerilogLogProvider : LogProviderBase
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
@@ -1773,7 +1797,9 @@ namespace YourRootNamespace.Logging.LogProviders
             return name => func("SourceContext", name, false);
         }
 
+#if !LIBLOG_PORTABLE
         [ExcludeFromCodeCoverage]
+#endif
         internal class SerilogLogger
         {
             private readonly object _logger;
@@ -1924,7 +1950,9 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
     internal class LoupeLogProvider : LogProviderBase
     {
         /// <summary>
@@ -1999,7 +2027,9 @@ namespace YourRootNamespace.Logging.LogProviders
             return callDelegate;
         }
 
+#if !LIBLOG_PORTABLE
         [ExcludeFromCodeCoverage]
+#endif
         internal class LoupeLogger
         {
             private const string LogSystem = "LibLog";
@@ -2058,7 +2088,9 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
     internal static class TraceEventTypeValues
     {
         internal static readonly Type Type;
@@ -2086,7 +2118,9 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
     internal static class LogMessageFormatter
     {
         //private static readonly Regex Pattern = new Regex(@"\{@?\w{1,}\}");
@@ -2171,7 +2205,9 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
     internal static class TypeExtensions
     {
         internal static ConstructorInfo GetConstructorPortable(this Type type, params Type[] types)
@@ -2261,7 +2297,9 @@ namespace YourRootNamespace.Logging.LogProviders
         }
     }
 
+#if !LIBLOG_PORTABLE
     [ExcludeFromCodeCoverage]
+#endif
     internal class DisposableAction : IDisposable
     {
         private readonly Action _onDispose;


### PR DESCRIPTION
This makes it easy for consumers of LibLog to exclude LibLog.cs from
their code coverage analysis.