### PR TITLE
Mapped context destructuring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ tools/**
 !tools/packages.config
 
 artifacts
+/src/.vs

--- a/src/LibLog.Tests.NLog4/LibLog.Tests.NLog4.csproj
+++ b/src/LibLog.Tests.NLog4/LibLog.Tests.NLog4.csproj
@@ -62,6 +62,9 @@
     <Compile Include="..\LibLog.Tests\LogProviders\LogExtensions.cs">
       <Link>LogExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\LibLog.Tests\LogProviders\MyMappedContext.cs">
+      <Link>MyMappedContext.cs</Link>
+    </Compile>
     <Compile Include="..\LibLog.Tests\LogProviders\NLogLogProviderLoggingTests.cs">
       <Link>NLogLogProviderLoggingTests.cs</Link>
     </Compile>

--- a/src/LibLog.Tests.Serilog2/LibLog.Tests.Serilog2.csproj
+++ b/src/LibLog.Tests.Serilog2/LibLog.Tests.Serilog2.csproj
@@ -80,6 +80,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="LogExtensions.cs" />
+    <Compile Include="MyMappedContext.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SerilogLogProviderLoggingTests.cs" />
   </ItemGroup>

--- a/src/LibLog.Tests.Serilog2/MyMappedContext.cs
+++ b/src/LibLog.Tests.Serilog2/MyMappedContext.cs
@@ -1,0 +1,26 @@
+﻿namespace LibLog.Logging.LogProviders
+{
+    using LogLevel = YourRootNamespace.Logging.LogLevel;
+
+    internal class MyMappedContext
+    {
+        public int ThirtySeven
+        {
+            get
+            {
+                return 37;
+            }
+        }
+
+        public string Name { get => name; set => name = value; }
+        public LogLevel Level { get => level; set => level = value; }
+
+        string name = "World";
+        LogLevel level = LogLevel.Trace;
+
+        public override string ToString()
+        {
+            return name;
+        }
+    }
+}

--- a/src/LibLog.Tests.Serilog2/SerilogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests.Serilog2/SerilogLogProviderLoggingTests.cs
@@ -120,6 +120,34 @@
             }
         }
 
+        [Fact]
+        public void Can_open_mapped_diagnostics_context_destructured()
+        {
+            var context = new MyMappedContext();
+
+            using (_logProvider.OpenMappedContext("key", context, true))
+            {
+                _sut.Info("m");
+
+                _logEvent.Properties.Keys.ShouldContain("key");
+                _logEvent.Properties["key"].ToString().ShouldBe("MyMappedContext { ThirtySeven: 37, Name: \"World\", Level: Trace }");
+            }
+        }
+
+        [Fact]
+        public void Can_open_mapped_diagnostics_context_not_destructured()
+        {
+            var context = new MyMappedContext();
+
+            using (_logProvider.OpenMappedContext("key", context, false))
+            {
+                _sut.Info("m");
+
+                _logEvent.Properties.Keys.ShouldContain("key");
+                _logEvent.Properties["key"].ToString().ShouldBe("\"World\"");
+            }
+        }
+
         [Theory]
         [InlineData(LogEventLevel.Verbose, new []{LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]
         [InlineData(LogEventLevel.Debug, new []{LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]

--- a/src/LibLog.Tests/LibLog.Tests.csproj
+++ b/src/LibLog.Tests/LibLog.Tests.csproj
@@ -138,6 +138,7 @@
     <Compile Include="LogProviders\Log4NetLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\EntLibLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\LogExtensions.cs" />
+    <Compile Include="LogProviders\MyMappedContext.cs" />
     <Compile Include="LogProviders\SerilogLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\NLogLogProviderLoggingTests.cs" />
     <Compile Include="LogProviderTests.cs" />

--- a/src/LibLog.Tests/LibLogPCL.Tests.csproj
+++ b/src/LibLog.Tests/LibLogPCL.Tests.csproj
@@ -134,6 +134,7 @@
     <Compile Include="LogProviders\LoupeLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\Log4NetLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\EntLibLogProviderLoggingTests.cs" />
+    <Compile Include="LogProviders\MyMappedContext.cs" />
     <Compile Include="LogProviders\SerilogLogProviderLoggingTests.cs" />
     <Compile Include="LogProviders\NLogLogProviderLoggingTests.cs" />
     <Compile Include="LogProviderTests.cs" />

--- a/src/LibLog.Tests/LogProviders/Log4NetLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/Log4NetLogProviderLoggingTests.cs
@@ -133,6 +133,36 @@
         }
 
         [Fact]
+        public void Can_open_mapped_diagnostics_context_destructured()
+        {
+            var context = new MyMappedContext();
+
+            using (_logProvider.OpenMappedContext("key", context, true))
+            {
+                _sut.Info("m");
+                var loggingEvent = _memoryAppender.GetEvents().Single();
+
+                loggingEvent.Properties.GetKeys().ShouldContain("key");
+                loggingEvent.Properties["key"].ShouldBe("World");
+            }
+        }
+
+        [Fact]
+        public void Can_open_mapped_diagnostics_context_not_destructured()
+        {
+            var context = new MyMappedContext();
+
+            using (_logProvider.OpenMappedContext("key", context, false))
+            {
+                _sut.Info("m");
+                var loggingEvent = _memoryAppender.GetEvents().Single();
+
+                loggingEvent.Properties.GetKeys().ShouldContain("key");
+                loggingEvent.Properties["key"].ShouldBe("World");
+            }
+        }
+
+        [Fact]
         public void Should_log_message_with_curly_brackets()
         {
             _sut.Log(LogLevel.Debug, () => "Query language substitutions: {'true'='1', 'false'='0', 'yes'=''Y'', 'no'=''N''}");

--- a/src/LibLog.Tests/LogProviders/MyMappedContext.cs
+++ b/src/LibLog.Tests/LogProviders/MyMappedContext.cs
@@ -1,0 +1,26 @@
+﻿namespace LibLog.Logging.LogProviders
+{
+    using LogLevel = YourRootNamespace.Logging.LogLevel;
+
+    internal class MyMappedContext
+    {
+        public int ThirtySeven
+        {
+            get
+            {
+                return 37;
+            }
+        }
+
+        public string Name { get => name; set => name = value; }
+        public LogLevel Level { get => level; set => level = value; }
+
+        string name = "World";
+        LogLevel level = LogLevel.Trace;
+
+        public override string ToString()
+        {
+            return name;
+        }
+    }
+}

--- a/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
@@ -136,5 +136,31 @@
                 _target.Logs[0].ShouldBe("INFO||value|m|");
             }
         }
+
+        [Fact]
+        public void Can_open_mapped_diagnostics_context_destructured()
+        {
+            var context = new MyMappedContext();
+
+            using (_logProvider.OpenMappedContext("key", context, true))
+            {
+                _sut.Info("m");
+
+                _target.Logs[0].ShouldBe("INFO||World|m|");
+            }
+        }
+
+        [Fact]
+        public void Can_open_mapped_diagnostics_context_not_destructured()
+        {
+            var context = new MyMappedContext();
+
+            using (_logProvider.OpenMappedContext("key", context, false))
+            {
+                _sut.Info("m");
+
+                _target.Logs[0].ShouldBe("INFO||World|m|");
+            }
+        }
     }
 }

--- a/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
@@ -120,6 +120,56 @@
             }
         }
 
+        internal class MyMappedContext
+        {
+            public int ThirtySeven
+            {
+                get
+                {
+                    return 37;
+                }
+            }
+
+            public string Name { get => name; set => name = value; }
+            public LogLevel Level { get => level; set => level = value; }
+
+            string name = "World";
+            LogLevel level = LogLevel.Trace;
+
+            public override string ToString()
+            {
+                return name;
+            }
+        }
+
+        [Fact]
+        public void Can_open_mapped_diagnostics_context_destructured()
+        {
+            var context = new MyMappedContext();
+
+            using (_logProvider.OpenMappedContext("key", context, true))
+            {
+                _sut.Info("m");
+
+                _logEvent.Properties.Keys.ShouldContain("key");
+                _logEvent.Properties["key"].ToString().ShouldBe("MyMappedContext { ThirtySeven: 37, Name: \"World\", Level: Trace }");
+            }
+        }
+
+        [Fact]
+        public void Can_open_mapped_diagnostics_context_not_destructured()
+        {
+            var context = new MyMappedContext();
+
+            using (_logProvider.OpenMappedContext("key", context, true))
+            {
+                _sut.Info("m");
+
+                _logEvent.Properties.Keys.ShouldContain("key");
+                _logEvent.Properties["key"].ToString().ShouldBe("\"name\"");
+            }
+        }
+
         [Theory]
         [InlineData(LogEventLevel.Verbose, new []{LogLevel.Trace, LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]
         [InlineData(LogEventLevel.Debug, new []{LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error, LogLevel.Fatal})]

--- a/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/SerilogLogProviderLoggingTests.cs
@@ -120,28 +120,6 @@
             }
         }
 
-        internal class MyMappedContext
-        {
-            public int ThirtySeven
-            {
-                get
-                {
-                    return 37;
-                }
-            }
-
-            public string Name { get => name; set => name = value; }
-            public LogLevel Level { get => level; set => level = value; }
-
-            string name = "World";
-            LogLevel level = LogLevel.Trace;
-
-            public override string ToString()
-            {
-                return name;
-            }
-        }
-
         [Fact]
         public void Can_open_mapped_diagnostics_context_destructured()
         {
@@ -161,12 +139,12 @@
         {
             var context = new MyMappedContext();
 
-            using (_logProvider.OpenMappedContext("key", context, true))
+            using (_logProvider.OpenMappedContext("key", context, false))
             {
                 _sut.Info("m");
 
                 _logEvent.Properties.Keys.ShouldContain("key");
-                _logEvent.Properties["key"].ToString().ShouldBe("\"name\"");
+                _logEvent.Properties["key"].ToString().ShouldBe("\"World\"");
             }
         }
 

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -1769,7 +1769,7 @@ namespace YourRootNamespace.Logging.LogProviders
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
         private static bool s_providerIsAvailableOverride = true;
-        private static Func<string, string, IDisposable> _pushProperty;
+        private static Func<string, object, bool, IDisposable> _pushProperty;
 
         [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "Serilog")]
         public SerilogLogProvider()

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -641,13 +641,13 @@ namespace YourRootNamespace.Logging
 #else
         internal
 #endif
-        static IDisposable OpenMappedContext(string key, string value)
+        static IDisposable OpenMappedContext(string key, object value, bool destructure = false)
         {
             ILogProvider logProvider = CurrentLogProvider ?? ResolveLogProvider();
 
             return logProvider == null
                 ? new DisposableAction(() => { })
-                : logProvider.OpenMappedContext(key, value);
+                : logProvider.OpenMappedContext(key, value, destructure);
         }
 #endif
 
@@ -833,7 +833,7 @@ namespace YourRootNamespace.Logging.LogProviders
             return _lazyOpenNdcMethod.Value(message);
         }
 
-        public IDisposable OpenMappedContext(string key, object value, bool destructure)
+        public IDisposable OpenMappedContext(string key, object value, bool destructure = false)
         {
             return _lazyOpenMdcMethod.Value(key, value, destructure);
         }


### PR DESCRIPTION
I was migrating some library code to LibLog that previously directly called Serilog and made heavy use of [destructuring](https://github.com/serilog/serilog/wiki/Structured-Data) and the `var logger = Log.ForContext("SomeKey", SomeValue)` contextual logger and `using (LogContext.PushProperty("RequestId", Request.Id))` ambient logging contexts [features](https://nblumhardt.com/2016/08/context-and-correlation-structured-logging-concepts-in-net-5/).

I found this LibLog change useful during the migration.

* A destructure flag has been added to OpenMappedContext like so: `IDisposable OpenMappedContext(string key, object value, bool destructure = false);`
* The type of the value parameter changed from string to object.
* The intent is that all exiting code in the world using LibLog should behave the same after this change is merged.
* The destructuring flag is only used by Serilog.
* Tests have been added for Serilog to verify this behavior.
* Tests have been added for log4net and NLog to verify that the destructuring flag is ignored.