### PR TITLE
Optimizing calls to ResolveLogProvider()

### DIFF
--- a/src/LibLog.Tests/LogProviderTests.cs
+++ b/src/LibLog.Tests/LogProviderTests.cs
@@ -21,7 +21,7 @@
             SerilogLogProvider.ProviderIsAvailableOverride = false;
             LoupeLogProvider.ProviderIsAvailableOverride = false;
 
-            var logProvider = LogProvider.ResolveLogProvider();
+            var logProvider = LogProvider.ForceResolveLogProvider();
             logProvider.ShouldBeOfType<NLogLogProvider>();
         }
 
@@ -35,7 +35,7 @@
             SerilogLogProvider.ProviderIsAvailableOverride = false;
             LoupeLogProvider.ProviderIsAvailableOverride = false;
 
-            var logProvider = LogProvider.ResolveLogProvider();
+            var logProvider = LogProvider.ForceResolveLogProvider();
             logProvider.ShouldBeOfType<Log4NetLogProvider>();
         }
 
@@ -49,7 +49,7 @@
             EntLibLogProvider.ProviderIsAvailableOverride = true;
             LoupeLogProvider.ProviderIsAvailableOverride = false;
 
-            var logProvider = LogProvider.ResolveLogProvider();
+            var logProvider = LogProvider.ForceResolveLogProvider();
             logProvider.ShouldBeOfType<EntLibLogProvider>();
         }
 
@@ -63,7 +63,7 @@
             SerilogLogProvider.ProviderIsAvailableOverride = true;
             LoupeLogProvider.ProviderIsAvailableOverride = false;
 
-            var logProvider = LogProvider.ResolveLogProvider();
+            var logProvider = LogProvider.ForceResolveLogProvider();
             logProvider.ShouldBeOfType<SerilogLogProvider>();
         }
 
@@ -77,7 +77,7 @@
             SerilogLogProvider.ProviderIsAvailableOverride = false;
             LoupeLogProvider.ProviderIsAvailableOverride = true;
 
-            var logProvider = LogProvider.ResolveLogProvider();
+            var logProvider = LogProvider.ForceResolveLogProvider();
             logProvider.ShouldBeOfType<LoupeLogProvider>();
         }
 

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -492,6 +492,7 @@ namespace YourRootNamespace.Logging
                                                "with a non-null value first.";
         private static dynamic s_currentLogProvider;
         private static Action<ILogProvider> s_onCurrentLogProviderSet;
+        private static Lazy<ILogProvider> s_resolvedLogProvider = new Lazy<ILogProvider>(() => ForceResolveLogProvider());
 
         [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
         static LogProvider()
@@ -693,6 +694,11 @@ namespace YourRootNamespace.Logging
         [SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "System.Console.WriteLine(System.String,System.Object,System.Object)")]
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         internal static ILogProvider ResolveLogProvider()
+        {
+            return s_resolvedLogProvider.Value;
+        }
+
+        internal static ILogProvider ForceResolveLogProvider()
         {
             try
             {

--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -1,4 +1,4 @@
-//===============================================================================
+﻿//===============================================================================
 // LibLog
 //
 // https://github.com/damianh/LibLog
@@ -691,13 +691,13 @@ namespace YourRootNamespace.Logging
         }
 #endif
 
-        [SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "System.Console.WriteLine(System.String,System.Object,System.Object)")]
-        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         internal static ILogProvider ResolveLogProvider()
         {
             return s_resolvedLogProvider.Value;
         }
 
+        [SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "System.Console.WriteLine(System.String,System.Object,System.Object)")]
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         internal static ILogProvider ForceResolveLogProvider()
         {
             try


### PR DESCRIPTION
There is no reason to perform the computation in ResolveLogProvider more than once. In this pull request, I cache the result of the computation of ResolveLogProvider using the Lazy<> class. If someone really wants to call this method again, he can call the internal variant named ForceResolveLogProvider.

See also [this issue](https://github.com/Code-Sharp/WampSharp/pull/202).