### PR TITLE
Disable resharper formatting of this file

### DIFF
--- a/src/LibLog/LibLog.cs
+++ b/src/LibLog/LibLog.cs
@@ -25,6 +25,7 @@
 // SOFTWARE.
 //===============================================================================
 
+// @formatter:off — disable resharper formatter after this line
 // ReSharper disable PossibleNullReferenceException
 
 // Define LIBLOG_PORTABLE conditional compilation symbol for PCL compatibility
@@ -2448,3 +2449,4 @@ namespace YourRootNamespace.LibLog.LogProviders
         }
     }
 }
+// @formatter:on — enable resharper formatter after this line


### PR DESCRIPTION
If we do 'clean up' on a project or solution we don't want resharper touching this file and splitting it into separate classes for instance.