### PR TITLE
Restore support for .NET Framework 4.5.2

### DIFF
--- a/src/LibLog.Tests.NoLogFwkReferences/LibLog.Tests.NoLogFwkReferences.csproj
+++ b/src/LibLog.Tests.NoLogFwkReferences/LibLog.Tests.NoLogFwkReferences.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461;net452</TargetFrameworks>
     <RootNamespace>LibLog.Logging</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/LibLog.Tests/LibLog.Tests.csproj
+++ b/src/LibLog.Tests/LibLog.Tests.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461;net452</TargetFrameworks>
     <RootNamespace>LibLog.Logging</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="Loupe.Agent.Core" Version="4.5.0.2" />
+    <PackageReference Include="Gibraltar.Agent" Version="4.6.4" Condition=" '$(TargetFramework)' == 'net452' " />
+    <PackageReference Include="Loupe.Agent.Core" Version="4.5.0.2" Condition=" '$(TargetFramework)' != 'net452' " />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NLog" Version="4.5.0" />
     <PackageReference Include="Serilog" Version="2.5.0" />

--- a/src/LibLog.Tests/LibLog.Tests.csproj
+++ b/src/LibLog.Tests/LibLog.Tests.csproj
@@ -4,8 +4,8 @@
     <RootNamespace>LibLog.Logging</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Gibraltar.Agent" Version="4.6.4" Condition=" '$(TargetFramework)' == 'net452' " />
+    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Loupe.Agent.Core" Version="4.5.0.2" Condition=" '$(TargetFramework)' != 'net452' " />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NLog" Version="4.5.0" />

--- a/src/LibLog/LibLog.csproj
+++ b/src/LibLog/LibLog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <LangVersion>7</LangVersion>
     <RootNamespace>YourRootNamespace.Logging</RootNamespace>
   </PropertyGroup>

--- a/src/LibLog/LibLog.nuspec
+++ b/src/LibLog/LibLog.nuspec
@@ -35,9 +35,13 @@ This package is a variation of option 3 but will automatically wire things up to
             <group targetFramework="netstandard2.0">
                 <dependency id="Microsoft.CSharp" version="4.4.0" />
             </group>
+            <group targetFramework="net452">
+                <dependency id="Microsoft.CSharp" version="4.4.0" />
+            </group>
         </dependencies>
     </metadata>
     <files>
         <file src="**/*.cs.pp" target="contentFiles/cs/netstandard2.0" />
+        <file src="**/*.cs.pp" target="contentFiles/cs/net452" />
     </files>
 </package>

--- a/src/LibLog/LogProviders/LoupeLogProvidercs.cs
+++ b/src/LibLog/LogProviders/LoupeLogProvidercs.cs
@@ -25,7 +25,8 @@
         );
 
         private readonly WriteDelegate _logWriteDelegate;
-        private const string LoupeAgentDll = "Loupe.Agent.NETCore";
+        private const string LoupeAgentNetCoreDll = "Loupe.Agent.NETCore";
+        private const string LoupeAgentNetFrameworkDll = "Gibraltar.Agent";
 
         public LoupeLogProvider()
         {
@@ -52,16 +53,21 @@
             return ProviderIsAvailableOverride && GetLogManagerType() != null;
         }
 
+        private static Type GetTypeFromCoreOrFrameworkDll(string typeName)
+        {
+            return Type.GetType($"{typeName}, {LoupeAgentNetCoreDll}") ?? Type.GetType($"{typeName}, {LoupeAgentNetFrameworkDll}");
+        }
+
         private static Type GetLogManagerType()
         {
-            return Type.GetType($"Gibraltar.Agent.Log, {LoupeAgentDll}");
+            return GetTypeFromCoreOrFrameworkDll("Gibraltar.Agent.Log");
         }
 
         private static WriteDelegate GetLogWriteDelegate()
         {
             var logManagerType = GetLogManagerType();
-            var logMessageSeverityType = Type.GetType($"Gibraltar.Agent.LogMessageSeverity, {LoupeAgentDll}");
-            var logWriteModeType = Type.GetType($"Gibraltar.Agent.LogWriteMode, {LoupeAgentDll}");
+            var logMessageSeverityType = GetTypeFromCoreOrFrameworkDll("Gibraltar.Agent.LogMessageSeverity");
+            var logWriteModeType = GetTypeFromCoreOrFrameworkDll("Gibraltar.Agent.LogWriteMode");
 
             var method = logManagerType.GetMethod(
                 "Write",

--- a/src/LibLog/LogProviders/LoupeLogProvidercs.cs.pp
+++ b/src/LibLog/LogProviders/LoupeLogProvidercs.cs.pp
@@ -25,7 +25,8 @@ namespace $rootnamespace$.Logging.LogProviders
         );
 
         private readonly WriteDelegate _logWriteDelegate;
-        private const string LoupeAgentDll = "Loupe.Agent.NETCore";
+        private const string LoupeAgentNetCoreDll = "Loupe.Agent.NETCore";
+        private const string LoupeAgentNetFrameworkDll = "Gibraltar.Agent";
 
         public LoupeLogProvider()
         {
@@ -52,16 +53,21 @@ namespace $rootnamespace$.Logging.LogProviders
             return ProviderIsAvailableOverride && GetLogManagerType() != null;
         }
 
+        private static Type GetTypeFromCoreOrFrameworkDll(string typeName)
+        {
+            return Type.GetType($"{typeName}, {LoupeAgentNetCoreDll}") ?? Type.GetType($"{typeName}, {LoupeAgentNetFrameworkDll}");
+        }
+
         private static Type GetLogManagerType()
         {
-            return Type.GetType($"Gibraltar.Agent.Log, {LoupeAgentDll}");
+            return GetTypeFromCoreOrFrameworkDll("Gibraltar.Agent.Log");
         }
 
         private static WriteDelegate GetLogWriteDelegate()
         {
             var logManagerType = GetLogManagerType();
-            var logMessageSeverityType = Type.GetType($"Gibraltar.Agent.LogMessageSeverity, {LoupeAgentDll}");
-            var logWriteModeType = Type.GetType($"Gibraltar.Agent.LogWriteMode, {LoupeAgentDll}");
+            var logMessageSeverityType = GetTypeFromCoreOrFrameworkDll("Gibraltar.Agent.LogMessageSeverity");
+            var logWriteModeType = GetTypeFromCoreOrFrameworkDll("Gibraltar.Agent.LogWriteMode");
 
             var method = logManagerType.GetMethod(
                 "Write",


### PR DESCRIPTION
As requested in #167, I would like to have support for .NET 4.5.2 restored using new project format.

The only IF-def I had to insert was for Loupe Agent, because there are two different packages for each framework. Moreover, I had to update Loupe provider in order to make it look for required types in both assemblies.

Unit tests for .NET 4.5.2 seem to be running fine.

I hope changes are good enough, let me know if there is something that I can improve.

Thanks!