### PR TITLE
Fix CS1573

### DIFF
--- a/src/LibLog/ILogProvider.cs
+++ b/src/LibLog/ILogProvider.cs
@@ -33,6 +33,7 @@ namespace YourRootNamespace.Logging
         /// </summary>
         /// <param name="key">A key.</param>
         /// <param name="value">A value.</param>
+        /// <param name="destructure">Determines whether to call the destructor or not.</param>
         /// <returns>A disposable that when disposed removes the map from the context.</returns>
         IDisposable OpenMappedContext(string key, object value, bool destructure = false);
     }

--- a/src/LibLog/ILogProvider.cs.pp
+++ b/src/LibLog/ILogProvider.cs.pp
@@ -33,6 +33,7 @@ namespace $rootnamespace$.Logging
         /// </summary>
         /// <param name="key">A key.</param>
         /// <param name="value">A value.</param>
+        /// <param name="destructure">Determines whether to call the destructor or not.</param>
         /// <returns>A disposable that when disposed removes the map from the context.</returns>
         IDisposable OpenMappedContext(string key, object value, bool destructure = false);
     }


### PR DESCRIPTION
Using 5.0.2 I get an error when compiling (I have warnings as errors):

[CS1573](https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs1573) - Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)

Although the interface is internal (I define LIBLOG_PROVIDERS_ONLY), the warning is still raised as one of the parameters is missing the XML documentation.