### PR TITLE
Use MappedDiagnosticsLogicalContext in NLog provider

### DIFF
--- a/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
+++ b/src/LibLog.Tests/LogProviders/NLogLogProviderLoggingTests.cs
@@ -21,7 +21,7 @@
             var config = new LoggingConfiguration();
             _target = new MemoryTarget
             {
-                Layout = "${level:uppercase=true}|${ndc}|${mdc:item=key}|${message}|${exception}"
+                Layout = "${level:uppercase=true}|${ndc}|${mdlc:item=key}|${message}|${exception}"
             };
             config.AddTarget("memory", _target);
             config.LoggingRules.Add(new LoggingRule("*", NLog.LogLevel.Trace, _target));

--- a/src/LibLog/LogProviders/NLogLogProvider.cs
+++ b/src/LibLog/LogProviders/NLogLogProvider.cs
@@ -43,7 +43,7 @@
 
         protected override OpenMdc GetOpenMdcMethod()
         {
-            var mdcContextType = Type.GetType("NLog.MappedDiagnosticsContext, NLog");
+            var mdcContextType = Type.GetType("NLog.MappedDiagnosticsLogicalContext, NLog");
 
             var setMethod = mdcContextType.GetMethod("Set", typeof(string), typeof(string));
             var removeMethod = mdcContextType.GetMethod("Remove", typeof(string));


### PR DESCRIPTION
Mapped Diagnostic Logical Context is the async version of the Mapped Diagnostics Context - a logical call context structure that keeps a dictionary of strings and provides methods to output them in layouts. Allows for maintaining state across asynchronous tasks and call contexts. 

The PR changes OpenMDC method to use the NLog MDLC instead of non-async friendly MDC restoring feature parity with Log4Net provider.
Note: it is a breaking change as it requires app owners to update NLog config

@damianh please have a look