### PR TITLE
Add missing XML comments to public members

### DIFF
--- a/src/LibLog/LogLevel.cs
+++ b/src/LibLog/LogLevel.cs
@@ -10,11 +10,34 @@
 #endif
         enum LogLevel
     {
+        /// <summary>
+        /// Trace
+        /// </summary>
         Trace,
+
+        /// <summary>
+        /// Debug
+        /// </summary>
         Debug,
+
+        /// <summary>
+        /// Info
+        /// </summary>
         Info,
+
+        /// <summary>
+        /// Warn
+        /// </summary>
         Warn,
+
+        /// <summary>
+        /// Error
+        /// </summary>
         Error,
+
+        /// <summary>
+        /// Fatal
+        /// </summary>
         Fatal
     }
 }

--- a/src/LibLog/LogLevel.cs.pp
+++ b/src/LibLog/LogLevel.cs.pp
@@ -11,11 +11,34 @@ namespace $rootnamespace$.Logging
 #endif
         enum LogLevel
     {
+        /// <summary>
+        /// Trace
+        /// </summary>
         Trace,
+
+        /// <summary>
+        /// Debug
+        /// </summary>
         Debug,
+
+        /// <summary>
+        /// Info
+        /// </summary>
         Info,
+
+        /// <summary>
+        /// Warn
+        /// </summary>
         Warn,
+
+        /// <summary>
+        /// Error
+        /// </summary>
         Error,
+
+        /// <summary>
+        /// Fatal
+        /// </summary>
         Fatal
     }
 }

--- a/src/LibLog/LogProviders/LibLogException.cs
+++ b/src/LibLog/LogProviders/LibLogException.cs
@@ -2,13 +2,25 @@
 {
     using System;
 
+    /// <summary>
+    /// Exception thrown by LibLog.
+    /// </summary>
     public class LibLogException : Exception
     {
+        /// <summary>
+        /// Initializes a new LibLogException with the specified message.
+        /// </summary>
+        /// <param name="message">The message</param>
         public LibLogException(string message)
             : base(message)
         {
         }
 
+        /// <summary>
+        /// Initializes a new LibLogException with the specified message and inner exception.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="inner">The inner exception.</param>
         public LibLogException(string message, Exception inner)
             : base(message, inner)
         {

--- a/src/LibLog/LogProviders/LibLogException.cs.pp
+++ b/src/LibLog/LogProviders/LibLogException.cs.pp
@@ -3,13 +3,25 @@ namespace $rootnamespace$.Logging.LogProviders
 {
     using System;
 
+	/// <summary>
+    /// Exception thrown by LibLog.
+    /// </summary>
     public class LibLogException : Exception
     {
+		/// <summary>
+        /// Initializes a new LibLogException with the specified message.
+        /// </summary>
+        /// <param name="message">The message</param>
         public LibLogException(string message)
             : base(message)
         {
         }
 
+		/// <summary>
+        /// Initializes a new LibLogException with the specified message and inner exception.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="inner">The inner exception.</param>
         public LibLogException(string message, Exception inner)
             : base(message, inner)
         {

--- a/src/LibLog/LoggerDelegate.cs
+++ b/src/LibLog/LoggerDelegate.cs
@@ -3,6 +3,14 @@ namespace YourRootNamespace.Logging
     using System;
 
 #if !LIBLOG_PROVIDERS_ONLY || LIBLOG_PUBLIC
+    /// <summary>
+    /// Logger delegate.
+    /// </summary>
+    /// <param name="logLevel">The log level</param>
+    /// <param name="messageFunc">The message function</param>
+    /// <param name="exception">The exception</param>
+    /// <param name="formatParameters">The format parameters</param>
+    /// <returns>A boolean.</returns>
     public
 #else
     internal

--- a/src/LibLog/LoggerDelegate.cs.pp
+++ b/src/LibLog/LoggerDelegate.cs.pp
@@ -4,6 +4,14 @@ namespace $rootnamespace$.Logging
     using System;
 
 #if !LIBLOG_PROVIDERS_ONLY || LIBLOG_PUBLIC
+	/// <summary>
+    /// Logger delegate.
+    /// </summary>
+    /// <param name="logLevel">The log level</param>
+    /// <param name="messageFunc">The message function</param>
+    /// <param name="exception">The exception</param>
+    /// <param name="formatParameters">The format parameters</param>
+    /// <returns>A boolean.</returns>
     public
 #else
     internal


### PR DESCRIPTION
As a code quality approach I set up my projects to treat all warnings as errors and prevent compilation if any are present.  Unfortunately this means that with the current NuGet package for LibLog I have to turn off this setting, otherwise I get a bunch of  "warning CS1591: Missing XML comment for publicly visible type or member." errors due to public members from the package being added to my project.

This pull request applies XML code comments to the members that are causing the problem.