### PR TITLE
More XML comments for public members

### DIFF
--- a/src/LibLog/LogExtensions.cs
+++ b/src/LibLog/LogExtensions.cs
@@ -3,6 +3,9 @@
     using System;
     using System.Diagnostics.CodeAnalysis;
 
+    /// <summary>
+    ///     Extension methods for the <see cref="ILog"/> interface.
+    /// </summary>
 #if LIBLOG_EXCLUDE_CODE_COVERAGE
     [ExcludeFromCodeCoverage]
 #endif
@@ -15,397 +18,486 @@
     {
         internal static readonly object[] EmptyParams = new object[0];
 
+        /// <summary>
+        ///     Check if the <see cref="LogLevel.Debug"/> log level is enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to check with.</param>
+        /// <returns>True if the log level is enabled; false otherwise.</returns>
         public static bool IsDebugEnabled(this ILog logger)
         {
             GuardAgainstNullLogger(logger);
             return logger.Log(LogLevel.Debug, null, null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Check if the <see cref="LogLevel.Error"/> log level is enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to check with.</param>
+        /// <returns>True if the log level is enabled; false otherwise.</returns>
         public static bool IsErrorEnabled(this ILog logger)
         {
             GuardAgainstNullLogger(logger);
             return logger.Log(LogLevel.Error, null, null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Check if the <see cref="LogLevel.Fatal"/> log level is enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to check with.</param>
+        /// <returns>True if the log level is enabled; false otherwise.</returns>
         public static bool IsFatalEnabled(this ILog logger)
         {
             GuardAgainstNullLogger(logger);
             return logger.Log(LogLevel.Fatal, null, null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Check if the <see cref="LogLevel.Info"/> log level is enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to check with.</param>
+        /// <returns>True if the log level is enabled; false otherwise.</returns>
         public static bool IsInfoEnabled(this ILog logger)
         {
             GuardAgainstNullLogger(logger);
             return logger.Log(LogLevel.Info, null, null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Check if the <see cref="LogLevel.Trace"/> log level is enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to check with.</param>
+        /// <returns>True if the log level is enabled; false otherwise.</returns>
         public static bool IsTraceEnabled(this ILog logger)
         {
             GuardAgainstNullLogger(logger);
             return logger.Log(LogLevel.Trace, null, null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Check if the <see cref="LogLevel.Warn"/> log level is enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to check with.</param>
+        /// <returns>True if the log level is enabled; false otherwise.</returns>
         public static bool IsWarnEnabled(this ILog logger)
         {
             GuardAgainstNullLogger(logger);
             return logger.Log(LogLevel.Warn, null, null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="messageFunc">The message function.</param>
         public static void Debug(this ILog logger, Func<string> messageFunc)
         {
             GuardAgainstNullLogger(logger);
             logger.Log(LogLevel.Debug, WrapLogInternal(messageFunc), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
         public static void Debug(this ILog logger, string message)
         {
             if (logger.IsDebugEnabled()) logger.Log(LogLevel.Debug, message.AsFunc(), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Debug(this ILog logger, string message, params object[] args)
         {
             logger.DebugFormat(message, args);
         }
 
-        public static void Debug(this ILog logger, string message, object arg0)
-        {
-            if (logger.IsDebugEnabled()) logger.DebugFormat(message, arg0);
-        }
-
-        public static void Debug(this ILog logger, string message, object arg0, object arg1)
-        {
-            if (logger.IsDebugEnabled()) logger.DebugFormat(message, arg0, arg1);
-        }
-
-        public static void Debug(this ILog logger, string message, object arg0, object arg1, object arg2)
-        {
-            if (logger.IsDebugEnabled()) logger.DebugFormat(message, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Debug(this ILog logger, Exception exception, string message, params object[] args)
         {
             logger.DebugException(message, exception, args);
         }
 
-        public static void Debug(this ILog logger, Exception exception, string message, object arg0)
-        {
-            if (logger.IsDebugEnabled()) logger.DebugException(message, exception, arg0);
-        }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void DebugFormat(this ILog logger, string message, params object[] args)
         {
             if (logger.IsDebugEnabled()) logger.LogFormat(LogLevel.Debug, message, args);
         }
 
-        public static void DebugFormat(this ILog logger, string message, object arg0)
-        {
-            if (logger.IsDebugEnabled()) logger.LogFormat(LogLevel.Debug, message, arg0);
-        }
-
-        public static void DebugFormat(this ILog logger, string message, object arg0, object arg1)
-        {
-            if (logger.IsDebugEnabled()) logger.LogFormat(LogLevel.Debug, message, arg0, arg1);
-        }
-
-        public static void DebugFormat(this ILog logger, string message, object arg0, object arg1, object arg2)
-        {
-            if (logger.IsDebugEnabled()) logger.LogFormat(LogLevel.Debug, message, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
         public static void DebugException(this ILog logger, string message, Exception exception)
         {
             if (logger.IsDebugEnabled()) logger.Log(LogLevel.Debug, message.AsFunc(), exception, EmptyParams);
         }
 
-        public static void DebugException(this ILog logger, string message, Exception exception, object formatParam0)
-        {
-            if (logger.IsDebugEnabled()) logger.Log(LogLevel.Debug, message.AsFunc(), exception, formatParam0);
-        }
-
-        public static void DebugException(this ILog logger, string message, Exception exception, object formatParam0,
-            object formatParam1)
-        {
-            if (logger.IsDebugEnabled())
-                logger.Log(LogLevel.Debug, message.AsFunc(), exception, formatParam0, formatParam1);
-        }
-
-        public static void DebugException(this ILog logger, string message, Exception exception, object formatParam0,
-            object formatParam1, object formatParam2)
-        {
-            if (logger.IsDebugEnabled())
-                logger.Log(LogLevel.Debug, message.AsFunc(), exception, formatParam0, formatParam1, formatParam2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void DebugException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {
             if (logger.IsDebugEnabled()) logger.Log(LogLevel.Debug, message.AsFunc(), exception, formatParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Error"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="messageFunc">The message function.</param>
         public static void Error(this ILog logger, Func<string> messageFunc)
         {
             GuardAgainstNullLogger(logger);
             logger.Log(LogLevel.Error, WrapLogInternal(messageFunc), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Error"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
         public static void Error(this ILog logger, string message)
         {
             if (logger.IsErrorEnabled()) logger.Log(LogLevel.Error, message.AsFunc(), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Error"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Error(this ILog logger, string message, params object[] args)
         {
             logger.ErrorFormat(message, args);
         }
 
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Error"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Error(this ILog logger, Exception exception, string message, params object[] args)
         {
             logger.ErrorException(message, exception, args);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Error"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void ErrorFormat(this ILog logger, string message, params object[] args)
         {
             if (logger.IsErrorEnabled()) logger.LogFormat(LogLevel.Error, message, args);
         }
 
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Error"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="formatParams">Optional format parameters for the message.</param>
         public static void ErrorException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {
             if (logger.IsErrorEnabled()) logger.Log(LogLevel.Error, message.AsFunc(), exception, formatParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Fatal"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="messageFunc">The message function.</param>
         public static void Fatal(this ILog logger, Func<string> messageFunc)
         {
             logger.Log(LogLevel.Fatal, WrapLogInternal(messageFunc), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Fatal"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
         public static void Fatal(this ILog logger, string message)
         {
             if (logger.IsFatalEnabled()) logger.Log(LogLevel.Fatal, message.AsFunc(), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Fatal"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Fatal(this ILog logger, string message, params object[] args)
         {
             logger.FatalFormat(message, args);
         }
 
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Fatal"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Fatal(this ILog logger, Exception exception, string message, params object[] args)
         {
             logger.FatalException(message, exception, args);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Fatal"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void FatalFormat(this ILog logger, string message, params object[] args)
         {
             if (logger.IsFatalEnabled()) logger.LogFormat(LogLevel.Fatal, message, args);
         }
 
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Fatal"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="formatParams">Optional format parameters for the message.</param>
         public static void FatalException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {
             if (logger.IsFatalEnabled()) logger.Log(LogLevel.Fatal, message.AsFunc(), exception, formatParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Info"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="messageFunc">The message function.</param>
         public static void Info(this ILog logger, Func<string> messageFunc)
         {
             GuardAgainstNullLogger(logger);
             logger.Log(LogLevel.Info, WrapLogInternal(messageFunc), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Info"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
         public static void Info(this ILog logger, string message)
         {
             if (logger.IsInfoEnabled()) logger.Log(LogLevel.Info, message.AsFunc(), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Info"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Info(this ILog logger, string message, params object[] args)
         {
             logger.InfoFormat(message, args);
         }
 
-        public static void Info(this ILog logger, string message, object arg0)
-        {
-            if (logger.IsInfoEnabled()) logger.InfoFormat(message, arg0);
-        }
-
-        public static void Info(this ILog logger, string message, object arg0, object arg1)
-        {
-            if (logger.IsInfoEnabled()) logger.InfoFormat(message, arg0, arg1);
-        }
-
-        public static void Info(this ILog logger, string message, object arg0, object arg1, object arg2)
-        {
-            if (logger.IsInfoEnabled()) logger.InfoFormat(message, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Info"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Info(this ILog logger, Exception exception, string message, params object[] args)
         {
             logger.InfoException(message, exception, args);
         }
 
-        public static void Info(this ILog logger, Exception exception, string message, object arg0)
-        {
-            if (logger.IsInfoEnabled()) logger.InfoException(message, exception, arg0);
-        }
-
-        public static void Info(this ILog logger, Exception exception, string message, object arg0, object arg1)
-        {
-            if (logger.IsInfoEnabled()) logger.InfoException(message, exception, arg0, arg1);
-        }
-
-        public static void Info(this ILog logger, Exception exception, string message, object arg0, object arg1,
-            object arg2)
-        {
-            if (logger.IsInfoEnabled()) logger.InfoException(message, exception, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Info"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void InfoFormat(this ILog logger, string message, params object[] args)
         {
             if (logger.IsInfoEnabled()) logger.LogFormat(LogLevel.Info, message, args);
         }
 
-        public static void InfoFormat(this ILog logger, string message, object arg0)
-        {
-            if (logger.IsInfoEnabled()) logger.LogFormat(LogLevel.Info, message, arg0);
-        }
 
-        public static void InfoFormat(this ILog logger, string message, object arg0, object arg1)
-        {
-            if (logger.IsInfoEnabled()) logger.LogFormat(LogLevel.Info, message, arg0, arg1);
-        }
-
-        public static void InfoFormat(this ILog logger, string message, object arg0, object arg1, object arg2)
-        {
-            if (logger.IsInfoEnabled()) logger.LogFormat(LogLevel.Info, message, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Info"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="formatParams">Optional format parameters for the message.</param>
         public static void InfoException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {
             if (logger.IsInfoEnabled()) logger.Log(LogLevel.Info, message.AsFunc(), exception, formatParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Trace"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="messageFunc">The message function.</param>
         public static void Trace(this ILog logger, Func<string> messageFunc)
         {
             GuardAgainstNullLogger(logger);
             logger.Log(LogLevel.Trace, WrapLogInternal(messageFunc), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Trace"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
         public static void Trace(this ILog logger, string message)
         {
             if (logger.IsTraceEnabled()) logger.Log(LogLevel.Trace, message.AsFunc(), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Trace"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Trace(this ILog logger, string message, params object[] args)
         {
             logger.TraceFormat(message, args);
         }
 
-        public static void Trace(this ILog logger, string message, object arg0)
-        {
-            if (logger.IsTraceEnabled()) logger.TraceFormat(message, arg0);
-        }
-
-        public static void Trace(this ILog logger, string message, object arg0, object arg1)
-        {
-            if (logger.IsTraceEnabled()) logger.TraceFormat(message, arg0, arg1);
-        }
-
-        public static void Trace(this ILog logger, string message, object arg0, object arg1, object arg2)
-        {
-            if (logger.IsTraceEnabled()) logger.TraceFormat(message, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Trace"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Trace(this ILog logger, Exception exception, string message, params object[] args)
         {
             logger.TraceException(message, exception, args);
         }
 
-        public static void Trace(this ILog logger, Exception exception, string message, object arg0)
-        {
-            if (logger.IsTraceEnabled()) logger.TraceException(message, exception, arg0);
-        }
-
-        public static void Trace(this ILog logger, Exception exception, string message, object arg0, object arg1)
-        {
-            if (logger.IsTraceEnabled()) logger.TraceException(message, exception, arg0, arg1);
-        }
-
-        public static void Trace(this ILog logger, Exception exception, string message, object arg0, object arg1,
-            object arg2)
-        {
-            if (logger.IsTraceEnabled()) logger.TraceException(message, exception, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Trace"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void TraceFormat(this ILog logger, string message, params object[] args)
         {
             if (logger.IsTraceEnabled()) logger.LogFormat(LogLevel.Trace, message, args);
         }
 
-        public static void TraceFormat(this ILog logger, string message, object arg0)
-        {
-            if (logger.IsTraceEnabled()) logger.LogFormat(LogLevel.Trace, message, arg0);
-        }
-
-        public static void TraceFormat(this ILog logger, string message, object arg0, object arg1)
-        {
-            if (logger.IsTraceEnabled()) logger.LogFormat(LogLevel.Trace, message, arg0, arg1);
-        }
-
-        public static void TraceFormat(this ILog logger, string message, object arg0, object arg1, object arg2)
-        {
-            if (logger.IsTraceEnabled()) logger.LogFormat(LogLevel.Trace, message, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Trace"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="formatParams">Optional format parameters for the message.</param>
         public static void TraceException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {
             if (logger.IsTraceEnabled()) logger.Log(LogLevel.Trace, message.AsFunc(), exception, formatParams);
         }
 
-        public static void TraceException(this ILog logger, string message, Exception exception, object formatParam0)
-        {
-            if (logger.IsTraceEnabled()) logger.Log(LogLevel.Trace, message.AsFunc(), exception, formatParam0);
-        }
-
-        public static void TraceException(this ILog logger, string message, Exception exception, object formatParam0,
-            object formatParam1)
-        {
-            if (logger.IsTraceEnabled())
-                logger.Log(LogLevel.Trace, message.AsFunc(), exception, formatParam0, formatParam1);
-        }
-
-        public static void TraceException(this ILog logger, string message, Exception exception, object formatParam0,
-            object formatParam1, object formatParam2)
-        {
-            if (logger.IsTraceEnabled())
-                logger.Log(LogLevel.Trace, message.AsFunc(), exception, formatParam0, formatParam1, formatParam2);
-        }
-
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Warn"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="messageFunc">The message function.</param>
         public static void Warn(this ILog logger, Func<string> messageFunc)
         {
             GuardAgainstNullLogger(logger);
             logger.Log(LogLevel.Warn, WrapLogInternal(messageFunc), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Warn"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
         public static void Warn(this ILog logger, string message)
         {
             if (logger.IsWarnEnabled()) logger.Log(LogLevel.Warn, message.AsFunc(), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Warn"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Warn(this ILog logger, string message, params object[] args)
         {
             logger.WarnFormat(message, args);
         }
 
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Warn"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Warn(this ILog logger, Exception exception, string message, params object[] args)
         {
             logger.WarnException(message, exception, args);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Warn"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void WarnFormat(this ILog logger, string message, params object[] args)
         {
             if (logger.IsWarnEnabled()) logger.LogFormat(LogLevel.Warn, message, args);
         }
 
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Warn"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="formatParams">Optional format parameters for the message.</param>
         public static void WarnException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {

--- a/src/LibLog/LogExtensions.cs.pp
+++ b/src/LibLog/LogExtensions.cs.pp
@@ -4,7 +4,10 @@ namespace $rootnamespace$.Logging
     using System;
     using System.Diagnostics.CodeAnalysis;
 
-#if !LIBLOG_EXCLUDE_CODE_COVERAGE
+    /// <summary>
+    ///     Extension methods for the <see cref="ILog"/> interface.
+    /// </summary>
+#if LIBLOG_EXCLUDE_CODE_COVERAGE
     [ExcludeFromCodeCoverage]
 #endif
 #if LIBLOG_PUBLIC
@@ -16,397 +19,486 @@ namespace $rootnamespace$.Logging
     {
         internal static readonly object[] EmptyParams = new object[0];
 
+        /// <summary>
+        ///     Check if the <see cref="LogLevel.Debug"/> log level is enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to check with.</param>
+        /// <returns>True if the log level is enabled; false otherwise.</returns>
         public static bool IsDebugEnabled(this ILog logger)
         {
             GuardAgainstNullLogger(logger);
             return logger.Log(LogLevel.Debug, null, null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Check if the <see cref="LogLevel.Error"/> log level is enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to check with.</param>
+        /// <returns>True if the log level is enabled; false otherwise.</returns>
         public static bool IsErrorEnabled(this ILog logger)
         {
             GuardAgainstNullLogger(logger);
             return logger.Log(LogLevel.Error, null, null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Check if the <see cref="LogLevel.Fatal"/> log level is enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to check with.</param>
+        /// <returns>True if the log level is enabled; false otherwise.</returns>
         public static bool IsFatalEnabled(this ILog logger)
         {
             GuardAgainstNullLogger(logger);
             return logger.Log(LogLevel.Fatal, null, null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Check if the <see cref="LogLevel.Info"/> log level is enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to check with.</param>
+        /// <returns>True if the log level is enabled; false otherwise.</returns>
         public static bool IsInfoEnabled(this ILog logger)
         {
             GuardAgainstNullLogger(logger);
             return logger.Log(LogLevel.Info, null, null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Check if the <see cref="LogLevel.Trace"/> log level is enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to check with.</param>
+        /// <returns>True if the log level is enabled; false otherwise.</returns>
         public static bool IsTraceEnabled(this ILog logger)
         {
             GuardAgainstNullLogger(logger);
             return logger.Log(LogLevel.Trace, null, null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Check if the <see cref="LogLevel.Warn"/> log level is enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to check with.</param>
+        /// <returns>True if the log level is enabled; false otherwise.</returns>
         public static bool IsWarnEnabled(this ILog logger)
         {
             GuardAgainstNullLogger(logger);
             return logger.Log(LogLevel.Warn, null, null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="messageFunc">The message function.</param>
         public static void Debug(this ILog logger, Func<string> messageFunc)
         {
             GuardAgainstNullLogger(logger);
             logger.Log(LogLevel.Debug, WrapLogInternal(messageFunc), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
         public static void Debug(this ILog logger, string message)
         {
             if (logger.IsDebugEnabled()) logger.Log(LogLevel.Debug, message.AsFunc(), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Debug(this ILog logger, string message, params object[] args)
         {
             logger.DebugFormat(message, args);
         }
 
-        public static void Debug(this ILog logger, string message, object arg0)
-        {
-            if (logger.IsDebugEnabled()) logger.DebugFormat(message, arg0);
-        }
-
-        public static void Debug(this ILog logger, string message, object arg0, object arg1)
-        {
-            if (logger.IsDebugEnabled()) logger.DebugFormat(message, arg0, arg1);
-        }
-
-        public static void Debug(this ILog logger, string message, object arg0, object arg1, object arg2)
-        {
-            if (logger.IsDebugEnabled()) logger.DebugFormat(message, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Debug(this ILog logger, Exception exception, string message, params object[] args)
         {
             logger.DebugException(message, exception, args);
         }
 
-        public static void Debug(this ILog logger, Exception exception, string message, object arg0)
-        {
-            if (logger.IsDebugEnabled()) logger.DebugException(message, exception, arg0);
-        }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void DebugFormat(this ILog logger, string message, params object[] args)
         {
             if (logger.IsDebugEnabled()) logger.LogFormat(LogLevel.Debug, message, args);
         }
 
-        public static void DebugFormat(this ILog logger, string message, object arg0)
-        {
-            if (logger.IsDebugEnabled()) logger.LogFormat(LogLevel.Debug, message, arg0);
-        }
-
-        public static void DebugFormat(this ILog logger, string message, object arg0, object arg1)
-        {
-            if (logger.IsDebugEnabled()) logger.LogFormat(LogLevel.Debug, message, arg0, arg1);
-        }
-
-        public static void DebugFormat(this ILog logger, string message, object arg0, object arg1, object arg2)
-        {
-            if (logger.IsDebugEnabled()) logger.LogFormat(LogLevel.Debug, message, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
         public static void DebugException(this ILog logger, string message, Exception exception)
         {
             if (logger.IsDebugEnabled()) logger.Log(LogLevel.Debug, message.AsFunc(), exception, EmptyParams);
         }
 
-        public static void DebugException(this ILog logger, string message, Exception exception, object formatParam0)
-        {
-            if (logger.IsDebugEnabled()) logger.Log(LogLevel.Debug, message.AsFunc(), exception, formatParam0);
-        }
-
-        public static void DebugException(this ILog logger, string message, Exception exception, object formatParam0,
-            object formatParam1)
-        {
-            if (logger.IsDebugEnabled())
-                logger.Log(LogLevel.Debug, message.AsFunc(), exception, formatParam0, formatParam1);
-        }
-
-        public static void DebugException(this ILog logger, string message, Exception exception, object formatParam0,
-            object formatParam1, object formatParam2)
-        {
-            if (logger.IsDebugEnabled())
-                logger.Log(LogLevel.Debug, message.AsFunc(), exception, formatParam0, formatParam1, formatParam2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Debug"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void DebugException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {
             if (logger.IsDebugEnabled()) logger.Log(LogLevel.Debug, message.AsFunc(), exception, formatParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Error"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="messageFunc">The message function.</param>
         public static void Error(this ILog logger, Func<string> messageFunc)
         {
             GuardAgainstNullLogger(logger);
             logger.Log(LogLevel.Error, WrapLogInternal(messageFunc), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Error"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
         public static void Error(this ILog logger, string message)
         {
             if (logger.IsErrorEnabled()) logger.Log(LogLevel.Error, message.AsFunc(), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Error"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Error(this ILog logger, string message, params object[] args)
         {
             logger.ErrorFormat(message, args);
         }
 
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Error"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Error(this ILog logger, Exception exception, string message, params object[] args)
         {
             logger.ErrorException(message, exception, args);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Error"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void ErrorFormat(this ILog logger, string message, params object[] args)
         {
             if (logger.IsErrorEnabled()) logger.LogFormat(LogLevel.Error, message, args);
         }
 
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Error"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="formatParams">Optional format parameters for the message.</param>
         public static void ErrorException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {
             if (logger.IsErrorEnabled()) logger.Log(LogLevel.Error, message.AsFunc(), exception, formatParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Fatal"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="messageFunc">The message function.</param>
         public static void Fatal(this ILog logger, Func<string> messageFunc)
         {
             logger.Log(LogLevel.Fatal, WrapLogInternal(messageFunc), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Fatal"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
         public static void Fatal(this ILog logger, string message)
         {
             if (logger.IsFatalEnabled()) logger.Log(LogLevel.Fatal, message.AsFunc(), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Fatal"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Fatal(this ILog logger, string message, params object[] args)
         {
             logger.FatalFormat(message, args);
         }
 
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Fatal"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Fatal(this ILog logger, Exception exception, string message, params object[] args)
         {
             logger.FatalException(message, exception, args);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Fatal"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void FatalFormat(this ILog logger, string message, params object[] args)
         {
             if (logger.IsFatalEnabled()) logger.LogFormat(LogLevel.Fatal, message, args);
         }
 
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Fatal"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="formatParams">Optional format parameters for the message.</param>
         public static void FatalException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {
             if (logger.IsFatalEnabled()) logger.Log(LogLevel.Fatal, message.AsFunc(), exception, formatParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Info"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="messageFunc">The message function.</param>
         public static void Info(this ILog logger, Func<string> messageFunc)
         {
             GuardAgainstNullLogger(logger);
             logger.Log(LogLevel.Info, WrapLogInternal(messageFunc), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Info"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
         public static void Info(this ILog logger, string message)
         {
             if (logger.IsInfoEnabled()) logger.Log(LogLevel.Info, message.AsFunc(), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Info"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Info(this ILog logger, string message, params object[] args)
         {
             logger.InfoFormat(message, args);
         }
 
-        public static void Info(this ILog logger, string message, object arg0)
-        {
-            if (logger.IsInfoEnabled()) logger.InfoFormat(message, arg0);
-        }
-
-        public static void Info(this ILog logger, string message, object arg0, object arg1)
-        {
-            if (logger.IsInfoEnabled()) logger.InfoFormat(message, arg0, arg1);
-        }
-
-        public static void Info(this ILog logger, string message, object arg0, object arg1, object arg2)
-        {
-            if (logger.IsInfoEnabled()) logger.InfoFormat(message, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Info"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Info(this ILog logger, Exception exception, string message, params object[] args)
         {
             logger.InfoException(message, exception, args);
         }
 
-        public static void Info(this ILog logger, Exception exception, string message, object arg0)
-        {
-            if (logger.IsInfoEnabled()) logger.InfoException(message, exception, arg0);
-        }
-
-        public static void Info(this ILog logger, Exception exception, string message, object arg0, object arg1)
-        {
-            if (logger.IsInfoEnabled()) logger.InfoException(message, exception, arg0, arg1);
-        }
-
-        public static void Info(this ILog logger, Exception exception, string message, object arg0, object arg1,
-            object arg2)
-        {
-            if (logger.IsInfoEnabled()) logger.InfoException(message, exception, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Info"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void InfoFormat(this ILog logger, string message, params object[] args)
         {
             if (logger.IsInfoEnabled()) logger.LogFormat(LogLevel.Info, message, args);
         }
 
-        public static void InfoFormat(this ILog logger, string message, object arg0)
-        {
-            if (logger.IsInfoEnabled()) logger.LogFormat(LogLevel.Info, message, arg0);
-        }
 
-        public static void InfoFormat(this ILog logger, string message, object arg0, object arg1)
-        {
-            if (logger.IsInfoEnabled()) logger.LogFormat(LogLevel.Info, message, arg0, arg1);
-        }
-
-        public static void InfoFormat(this ILog logger, string message, object arg0, object arg1, object arg2)
-        {
-            if (logger.IsInfoEnabled()) logger.LogFormat(LogLevel.Info, message, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Info"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="formatParams">Optional format parameters for the message.</param>
         public static void InfoException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {
             if (logger.IsInfoEnabled()) logger.Log(LogLevel.Info, message.AsFunc(), exception, formatParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Trace"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="messageFunc">The message function.</param>
         public static void Trace(this ILog logger, Func<string> messageFunc)
         {
             GuardAgainstNullLogger(logger);
             logger.Log(LogLevel.Trace, WrapLogInternal(messageFunc), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Trace"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
         public static void Trace(this ILog logger, string message)
         {
             if (logger.IsTraceEnabled()) logger.Log(LogLevel.Trace, message.AsFunc(), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Trace"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Trace(this ILog logger, string message, params object[] args)
         {
             logger.TraceFormat(message, args);
         }
 
-        public static void Trace(this ILog logger, string message, object arg0)
-        {
-            if (logger.IsTraceEnabled()) logger.TraceFormat(message, arg0);
-        }
-
-        public static void Trace(this ILog logger, string message, object arg0, object arg1)
-        {
-            if (logger.IsTraceEnabled()) logger.TraceFormat(message, arg0, arg1);
-        }
-
-        public static void Trace(this ILog logger, string message, object arg0, object arg1, object arg2)
-        {
-            if (logger.IsTraceEnabled()) logger.TraceFormat(message, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Trace"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Trace(this ILog logger, Exception exception, string message, params object[] args)
         {
             logger.TraceException(message, exception, args);
         }
 
-        public static void Trace(this ILog logger, Exception exception, string message, object arg0)
-        {
-            if (logger.IsTraceEnabled()) logger.TraceException(message, exception, arg0);
-        }
-
-        public static void Trace(this ILog logger, Exception exception, string message, object arg0, object arg1)
-        {
-            if (logger.IsTraceEnabled()) logger.TraceException(message, exception, arg0, arg1);
-        }
-
-        public static void Trace(this ILog logger, Exception exception, string message, object arg0, object arg1,
-            object arg2)
-        {
-            if (logger.IsTraceEnabled()) logger.TraceException(message, exception, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Trace"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void TraceFormat(this ILog logger, string message, params object[] args)
         {
             if (logger.IsTraceEnabled()) logger.LogFormat(LogLevel.Trace, message, args);
         }
 
-        public static void TraceFormat(this ILog logger, string message, object arg0)
-        {
-            if (logger.IsTraceEnabled()) logger.LogFormat(LogLevel.Trace, message, arg0);
-        }
-
-        public static void TraceFormat(this ILog logger, string message, object arg0, object arg1)
-        {
-            if (logger.IsTraceEnabled()) logger.LogFormat(LogLevel.Trace, message, arg0, arg1);
-        }
-
-        public static void TraceFormat(this ILog logger, string message, object arg0, object arg1, object arg2)
-        {
-            if (logger.IsTraceEnabled()) logger.LogFormat(LogLevel.Trace, message, arg0, arg1, arg2);
-        }
-
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Trace"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="formatParams">Optional format parameters for the message.</param>
         public static void TraceException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {
             if (logger.IsTraceEnabled()) logger.Log(LogLevel.Trace, message.AsFunc(), exception, formatParams);
         }
 
-        public static void TraceException(this ILog logger, string message, Exception exception, object formatParam0)
-        {
-            if (logger.IsTraceEnabled()) logger.Log(LogLevel.Trace, message.AsFunc(), exception, formatParam0);
-        }
-
-        public static void TraceException(this ILog logger, string message, Exception exception, object formatParam0,
-            object formatParam1)
-        {
-            if (logger.IsTraceEnabled())
-                logger.Log(LogLevel.Trace, message.AsFunc(), exception, formatParam0, formatParam1);
-        }
-
-        public static void TraceException(this ILog logger, string message, Exception exception, object formatParam0,
-            object formatParam1, object formatParam2)
-        {
-            if (logger.IsTraceEnabled())
-                logger.Log(LogLevel.Trace, message.AsFunc(), exception, formatParam0, formatParam1, formatParam2);
-        }
-
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Warn"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="messageFunc">The message function.</param>
         public static void Warn(this ILog logger, Func<string> messageFunc)
         {
             GuardAgainstNullLogger(logger);
             logger.Log(LogLevel.Warn, WrapLogInternal(messageFunc), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Warn"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
         public static void Warn(this ILog logger, string message)
         {
             if (logger.IsWarnEnabled()) logger.Log(LogLevel.Warn, message.AsFunc(), null, EmptyParams);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Warn"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Warn(this ILog logger, string message, params object[] args)
         {
             logger.WarnFormat(message, args);
         }
 
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Warn"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void Warn(this ILog logger, Exception exception, string message, params object[] args)
         {
             logger.WarnException(message, exception, args);
         }
 
+        /// <summary>
+        ///     Logs a message at the <see cref="LogLevel.Warn"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">Optional format parameters for the message.</param>
         public static void WarnFormat(this ILog logger, string message, params object[] args)
         {
             if (logger.IsWarnEnabled()) logger.LogFormat(LogLevel.Warn, message, args);
         }
 
+        /// <summary>
+        ///     Logs an exception at the <see cref="LogLevel.Warn"/> log level, if enabled.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILog"/> to use.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="formatParams">Optional format parameters for the message.</param>
         public static void WarnException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {

--- a/src/LibLog/LogProviders/LibLogException.cs.pp
+++ b/src/LibLog/LogProviders/LibLogException.cs.pp
@@ -3,12 +3,12 @@ namespace $rootnamespace$.Logging.LogProviders
 {
     using System;
 
-	/// <summary>
+    /// <summary>
     /// Exception thrown by LibLog.
     /// </summary>
     public class LibLogException : Exception
     {
-		/// <summary>
+        /// <summary>
         /// Initializes a new LibLogException with the specified message.
         /// </summary>
         /// <param name="message">The message</param>
@@ -17,7 +17,7 @@ namespace $rootnamespace$.Logging.LogProviders
         {
         }
 
-		/// <summary>
+        /// <summary>
         /// Initializes a new LibLogException with the specified message and inner exception.
         /// </summary>
         /// <param name="message">The message.</param>

--- a/src/LibLog/LogProviders/LogMessageFormatter.cs.pp
+++ b/src/LibLog/LogProviders/LogMessageFormatter.cs.pp
@@ -2,8 +2,8 @@
 namespace $rootnamespace$.Logging.LogProviders
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
     using System.Text.RegularExpressions;

--- a/src/LibLog/LogProviders/LogProviderBase.cs
+++ b/src/LibLog/LogProviders/LogProviderBase.cs
@@ -3,6 +3,9 @@
     using System;
     using System.Diagnostics.CodeAnalysis;
 
+    /// <summary>
+    ///     Base class for specific log providers.
+    /// </summary>
 #if LIBLOG_EXCLUDE_CODE_COVERAGE
     [ExcludeFromCodeCoverage]
 #endif
@@ -15,10 +18,18 @@
     {
         private static readonly IDisposable NoopDisposableInstance = new DisposableAction();
         private readonly Lazy<OpenMdc> _lazyOpenMdcMethod;
+
+        /// <summary>
+        ///     Error message should initializing the log provider fail.
+        /// </summary>
         protected const string ErrorInitializingProvider = "Unable to log due to problem initializing the log provider. See inner exception for details.";
 
         private readonly Lazy<OpenNdc> _lazyOpenNdcMethod;
 
+        /// <summary>
+        ///     Initialize an instance of the <see cref="LogProviderBase"/> class by initializing the references
+        ///     to the nested and mapped diagnostics context-obtaining functions.
+        /// </summary>
         protected LogProviderBase()
         {
             _lazyOpenNdcMethod
@@ -27,30 +38,67 @@
                 = new Lazy<OpenMdc>(GetOpenMdcMethod);
         }
 
+        /// <summary>
+        /// Gets the specified named logger.
+        /// </summary>
+        /// <param name="name">Name of the logger.</param>
+        /// <returns>The logger reference.</returns>
         public abstract Logger GetLogger(string name);
 
+        /// <summary>
+        /// Opens a nested diagnostics context. Not supported in EntLib logging.
+        /// </summary>
+        /// <param name="message">The message to add to the diagnostics context.</param>
+        /// <returns>A disposable that when disposed removes the message from the context.</returns>
         public IDisposable OpenNestedContext(string message)
         {
             return _lazyOpenNdcMethod.Value(message);
         }
 
+        /// <summary>
+        /// Opens a mapped diagnostics context. Not supported in EntLib logging.
+        /// </summary>
+        /// <param name="key">A key.</param>
+        /// <param name="value">A value.</param>
+        /// <param name="destructure">Determines whether to call the destructor or not.</param>
+        /// <returns>A disposable that when disposed removes the map from the context.</returns>
         public IDisposable OpenMappedContext(string key, object value, bool destructure = false)
         {
             return _lazyOpenMdcMethod.Value(key, value, destructure);
         }
 
+        /// <summary>
+        ///     Returns the provider-specific method to open a nested diagnostics context.
+        /// </summary>
+        /// <returns>A provider-specific method to open a nested diagnostics context.</returns>
         protected virtual OpenNdc GetOpenNdcMethod()
         {
             return _ => NoopDisposableInstance;
         }
 
+        /// <summary>
+        ///     Returns the provider-specific method to open a mapped diagnostics context.
+        /// </summary>
+        /// <returns>A provider-specific method to open a mapped diagnostics context.</returns>
         protected virtual OpenMdc GetOpenMdcMethod()
         {
             return (_, __, ___) => NoopDisposableInstance;
         }
 
+        /// <summary>
+        ///     Delegate defining the signature of the method opening a nested diagnostics context.
+        /// </summary>
+        /// <param name="message">The message to add to the diagnostics context.</param>
+        /// <returns>A disposable that when disposed removes the message from the context.</returns>
         protected delegate IDisposable OpenNdc(string message);
 
+        /// <summary>
+        ///     Delegate defining the signature of the method opening a mapped diagnostics context.
+        /// </summary>
+        /// <param name="key">A key.</param>
+        /// <param name="value">A value.</param>
+        /// <param name="destructure">Determines whether to call the destructor or not.</param>
+        /// <returns>A disposable that when disposed removes the map from the context.</returns>
         protected delegate IDisposable OpenMdc(string key, object value, bool destructure);
     }
 }

--- a/src/LibLog/LogProviders/LogProviderBase.cs.pp
+++ b/src/LibLog/LogProviders/LogProviderBase.cs.pp
@@ -4,6 +4,9 @@ namespace $rootnamespace$.Logging.LogProviders
     using System;
     using System.Diagnostics.CodeAnalysis;
 
+    /// <summary>
+    ///     Base class for specific log providers.
+    /// </summary>
 #if LIBLOG_EXCLUDE_CODE_COVERAGE
     [ExcludeFromCodeCoverage]
 #endif
@@ -16,10 +19,18 @@ namespace $rootnamespace$.Logging.LogProviders
     {
         private static readonly IDisposable NoopDisposableInstance = new DisposableAction();
         private readonly Lazy<OpenMdc> _lazyOpenMdcMethod;
+
+        /// <summary>
+        ///     Error message should initializing the log provider fail.
+        /// </summary>
         protected const string ErrorInitializingProvider = "Unable to log due to problem initializing the log provider. See inner exception for details.";
 
         private readonly Lazy<OpenNdc> _lazyOpenNdcMethod;
 
+        /// <summary>
+        ///     Initialize an instance of the <see cref="LogProviderBase"/> class by initializing the references
+        ///     to the nested and mapped diagnostics context-obtaining functions.
+        /// </summary>
         protected LogProviderBase()
         {
             _lazyOpenNdcMethod
@@ -28,30 +39,67 @@ namespace $rootnamespace$.Logging.LogProviders
                 = new Lazy<OpenMdc>(GetOpenMdcMethod);
         }
 
+        /// <summary>
+        /// Gets the specified named logger.
+        /// </summary>
+        /// <param name="name">Name of the logger.</param>
+        /// <returns>The logger reference.</returns>
         public abstract Logger GetLogger(string name);
 
+        /// <summary>
+        /// Opens a nested diagnostics context. Not supported in EntLib logging.
+        /// </summary>
+        /// <param name="message">The message to add to the diagnostics context.</param>
+        /// <returns>A disposable that when disposed removes the message from the context.</returns>
         public IDisposable OpenNestedContext(string message)
         {
             return _lazyOpenNdcMethod.Value(message);
         }
 
+        /// <summary>
+        /// Opens a mapped diagnostics context. Not supported in EntLib logging.
+        /// </summary>
+        /// <param name="key">A key.</param>
+        /// <param name="value">A value.</param>
+        /// <param name="destructure">Determines whether to call the destructor or not.</param>
+        /// <returns>A disposable that when disposed removes the map from the context.</returns>
         public IDisposable OpenMappedContext(string key, object value, bool destructure = false)
         {
             return _lazyOpenMdcMethod.Value(key, value, destructure);
         }
 
+        /// <summary>
+        ///     Returns the provider-specific method to open a nested diagnostics context.
+        /// </summary>
+        /// <returns>A provider-specific method to open a nested diagnostics context.</returns>
         protected virtual OpenNdc GetOpenNdcMethod()
         {
             return _ => NoopDisposableInstance;
         }
 
+        /// <summary>
+        ///     Returns the provider-specific method to open a mapped diagnostics context.
+        /// </summary>
+        /// <returns>A provider-specific method to open a mapped diagnostics context.</returns>
         protected virtual OpenMdc GetOpenMdcMethod()
         {
             return (_, __, ___) => NoopDisposableInstance;
         }
 
+        /// <summary>
+        ///     Delegate defining the signature of the method opening a nested diagnostics context.
+        /// </summary>
+        /// <param name="message">The message to add to the diagnostics context.</param>
+        /// <returns>A disposable that when disposed removes the message from the context.</returns>
         protected delegate IDisposable OpenNdc(string message);
 
+        /// <summary>
+        ///     Delegate defining the signature of the method opening a mapped diagnostics context.
+        /// </summary>
+        /// <param name="key">A key.</param>
+        /// <param name="value">A value.</param>
+        /// <param name="destructure">Determines whether to call the destructor or not.</param>
+        /// <returns>A disposable that when disposed removes the map from the context.</returns>
         protected delegate IDisposable OpenMdc(string key, object value, bool destructure);
     }
 }

--- a/src/LibLog/LoggerDelegate.cs.pp
+++ b/src/LibLog/LoggerDelegate.cs.pp
@@ -4,7 +4,7 @@ namespace $rootnamespace$.Logging
     using System;
 
 #if !LIBLOG_PROVIDERS_ONLY || LIBLOG_PUBLIC
-	/// <summary>
+    /// <summary>
     /// Logger delegate.
     /// </summary>
     /// <param name="logLevel">The log level</param>


### PR DESCRIPTION
Similar to #185 , this adds more XML comments, this time to members which are publicly visible with the LIBLOG_PUBLIC option set, and for the same reason: avoiding 80+ CS1591 warnings when compiling projects that include LibLog and use this option.

(While doing this, I also removed some efficiency logging extension methods - non-params versions redundant with the params versions - since in this case, they just shuffle the params array creation slightly down the call stack. This should cause no change in compilation behavior, and all tests still pass.)
