### PR TITLE
Update parameter name in XML comment to prevent warning CS1572.

### DIFF
--- a/src/LibLog/LogExtensions.cs
+++ b/src/LibLog/LogExtensions.cs
@@ -159,7 +159,7 @@
         /// <param name="logger">The <see cref="ILog"/> to use.</param>
         /// <param name="exception">The exception.</param>
         /// <param name="message">The message.</param>
-        /// <param name="args">Optional format parameters for the message.</param>
+        /// <param name="formatParams">Optional format parameters for the message.</param>
         public static void DebugException(this ILog logger, string message, Exception exception,
             params object[] formatParams)
         {


### PR DESCRIPTION
When using LibLog in my projects I receive the warning CS1572: XML comment has 
a param tag for 'args', but there is no parameter by that name.
This pull request fixes this.