### PR TITLE
Downgrade csharp version to compatible with c# 4.0

### DIFF
--- a/src/LibLog.Example.ColoredConsoleLogProvider/ColoredConsoleLogProvider.cs
+++ b/src/LibLog.Example.ColoredConsoleLogProvider/ColoredConsoleLogProvider.cs
@@ -23,7 +23,7 @@
             return (logLevel, messageFunc, exception, formatParameters) =>
             {
                 if (messageFunc == null)
-                {
+                {   
                     return true; // All log levels are enabled
                 }
 

--- a/src/LibLog/LibLog.csproj
+++ b/src/LibLog/LibLog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
-    <LangVersion>7</LangVersion>
+    <LangVersion>4</LangVersion>
     <RootNamespace>YourRootNamespace.Logging</RootNamespace>
   </PropertyGroup>
 </Project>

--- a/src/LibLog/LogProviders/Log4NetLogProvider.cs
+++ b/src/LibLog/LogProviders/Log4NetLogProvider.cs
@@ -22,7 +22,13 @@
             _getLoggerByNameDelegate = GetGetLoggerMethodCall();
         }
 
-        public static bool ProviderIsAvailableOverride { get; set; } = true;
+        private static bool s_providerIsAvailableOverride = true;
+
+        public static bool ProviderIsAvailableOverride
+        {
+            get { return s_providerIsAvailableOverride; }
+            set { s_providerIsAvailableOverride = value; }
+        }
 
         public override Logger GetLogger(string name)
         {
@@ -306,10 +312,12 @@
 
                 if (!IsLogLevelEnable(logLevel)) return false;
 
+                IEnumerable<string> patternMatches;
+
                 var formattedMessage =
                     LogMessageFormatter.FormatStructuredMessage(messageFunc(),
                         formatParameters,
-                        out var patternMatches);
+                        out patternMatches);
 
                 var callerStackBoundaryType = typeof(Log4NetLogger);
                 // Callsite HACK - Extract the callsite-logger-type from the messageFunc

--- a/src/LibLog/LogProviders/LogMessageFormatter.cs
+++ b/src/LibLog/LogProviders/LogMessageFormatter.cs
@@ -62,7 +62,7 @@
             {
                 var arg = match.Groups["arg"].Value;
 
-				int result;
+                int result;
                 if (!int.TryParse(arg, out result))
                 {
                     processedArguments = processedArguments ?? new List<string>(formatParameters.Length);

--- a/src/LibLog/LogProviders/LogProviderBase.cs
+++ b/src/LibLog/LogProviders/LogProviderBase.cs
@@ -114,7 +114,7 @@
         /// <returns>The requested type or null if it was not found.</returns>
         protected static Type FindType(string typeName, string assemblyName)
         {
-            return FindType(typeName, new[] {assemblyName});
+            return FindType(typeName, new[] { assemblyName });
         }
 
         /// <summary>
@@ -126,7 +126,7 @@
         protected static Type FindType(string typeName, IReadOnlyList<string> assemblyNames)
         {
             return assemblyNames
-                       .Select(assemblyName => Type.GetType($"{typeName}, {assemblyName}"))
+                       .Select(assemblyName => Type.GetType(string.Format("{0}, {1}", typeName, assemblyName)))
                        .FirstOrDefault(type => type != null) ?? Type.GetType(typeName);
         }
     }

--- a/src/LibLog/LogProviders/LoupeLogProvidercs.cs
+++ b/src/LibLog/LogProviders/LoupeLogProvidercs.cs
@@ -37,13 +37,19 @@
             _logWriteDelegate = GetLogWriteDelegate();
         }
 
+        private static bool s_providerIsAvaiableOverride = true;
+
         /// <summary>
         ///     Gets or sets a value indicating whether [provider is available override]. Used in tests.
         /// </summary>
         /// <value>
         ///     <c>true</c> if [provider is available override]; otherwise, <c>false</c>.
         /// </value>
-        public static bool ProviderIsAvailableOverride { get; set; } = true;
+        public static bool ProviderIsAvailableOverride
+        {
+            get { return s_providerIsAvaiableOverride; }
+            set { s_providerIsAvaiableOverride = value; }
+        }
 
         public override Logger GetLogger(string name)
         {
@@ -57,7 +63,7 @@
 
         private static Type GetTypeFromCoreOrFrameworkDll(string typeName)
         {
-            return FindType(typeName, new[] {LoupeAgentNetCoreDll, LoupeAgentNetFrameworkDll});
+            return FindType(typeName, new[] { LoupeAgentNetCoreDll, LoupeAgentNetFrameworkDll });
         }
 
         private static Type GetLogManagerType()
@@ -76,7 +82,7 @@
                 logMessageSeverityType, typeof(string), typeof(int), typeof(Exception), typeof(bool),
                 logWriteModeType, typeof(string), typeof(string), typeof(string), typeof(string), typeof(object[]));
 
-            var callDelegate = (WriteDelegate) method.CreateDelegate(typeof(WriteDelegate));
+            var callDelegate = (WriteDelegate)method.CreateDelegate(typeof(WriteDelegate));
             return callDelegate;
         }
 
@@ -132,7 +138,7 @@
                     case LogLevel.Fatal:
                         return TraceEventTypeValues.Critical;
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(logLevel));
+                        throw new ArgumentOutOfRangeException("logLevel");
                 }
             }
         }

--- a/src/LibLog/LogProviders/NLogLogProvider.cs
+++ b/src/LibLog/LogProviders/NLogLogProvider.cs
@@ -1,8 +1,8 @@
 ﻿namespace YourRootNamespace.Logging.LogProviders
 {
     using System;
-	using System.Collections.Generic;
-	using System.Diagnostics.CodeAnalysis;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Linq.Expressions;
 
@@ -25,7 +25,7 @@
         {
             ProviderIsAvailableOverride = true;
         }
-        
+
         public static bool ProviderIsAvailableOverride { get; set; }
 
         public override Logger GetLogger(string name)
@@ -289,7 +289,7 @@
                         var formatMessage = messageFunc();
                         if (!s_structuredLoggingEnabled)
                         {
-							IEnumerable<string> _;
+                            IEnumerable<string> _;
                             formatMessage =
                                 LogMessageFormatter.FormatStructuredMessage(formatMessage,
                                     formatParameters,
@@ -468,7 +468,7 @@
                     case LogLevel.Fatal:
                         return s_levelFatal;
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null);
+                        throw new ArgumentOutOfRangeException("logLevel", logLevel, null);
                 }
             }
 

--- a/src/LibLog/LogProviders/SerilogLogProvider.cs
+++ b/src/LibLog/LogProviders/SerilogLogProvider.cs
@@ -20,23 +20,37 @@
             s_pushProperty = GetPushProperty();
         }
 
-        public static bool ProviderIsAvailableOverride { get; set; } = true;
+        private static bool s_providerIsAvailableOverride = true;
+
+        public static bool ProviderIsAvailableOverride
+        {
+            get { return s_providerIsAvailableOverride; }
+            set { s_providerIsAvailableOverride = value; }
+        }
 
         public override Logger GetLogger(string name)
-            => new SerilogLogger(_getLoggerByNameDelegate(name)).Log;
+        {
+            return new SerilogLogger(_getLoggerByNameDelegate(name)).Log;
+        }
 
         internal static bool IsLoggerAvailable()
-            => ProviderIsAvailableOverride && GetLogManagerType() != null;
+        {
+            return ProviderIsAvailableOverride && GetLogManagerType() != null;
+        }
 
         protected override OpenNdc GetOpenNdcMethod()
-            => message => s_pushProperty("NDC", message, false);
+        {
+            return (message) => s_pushProperty("NDC", message, false);
+        }
 
         protected override OpenMdc GetOpenMdcMethod()
-            => (key, value, destructure) => s_pushProperty(key, value, destructure);
+        {
+            return (key, value, destructure) => s_pushProperty(key, value, destructure);
+        }
 
         private static Func<string, object, bool, IDisposable> GetPushProperty()
         {
-            var ndcContextType = FindType("Serilog.Context.LogContext", new[] {"Serilog", "Serilog.FullNetFx"});
+            var ndcContextType = FindType("Serilog.Context.LogContext", new[] { "Serilog", "Serilog.FullNetFx" });
 
             var pushPropertyMethod = ndcContextType.GetMethod(
                 "PushProperty",
@@ -61,7 +75,9 @@
         }
 
         private static Type GetLogManagerType()
-            => FindType("Serilog.Log", "Serilog");
+        {
+            return FindType("Serilog.Log", "Serilog");
+        }
 
         private static Func<string, object> GetForContextMethodCall()
         {

--- a/src/LibLog/LoggerExecutionWrapper.cs
+++ b/src/LibLog/LoggerExecutionWrapper.cs
@@ -20,7 +20,7 @@
             _getIsDisabled = getIsDisabled ?? (() => false);
         }
 
-        internal Logger WrappedLogger { get; }
+        internal Logger WrappedLogger { get; private set; }
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception = null,
@@ -49,7 +49,7 @@
                     formatParameters);
             }
 
-            var WrappedMessageFunc = new Func<string>(() => 
+            var WrappedMessageFunc = new Func<string>(() =>
             {
                 try
                 {


### PR DESCRIPTION
Hi, I am post this pull request cause there still exist a lot of library that use c# version lower than C#7.0. Thus, if there can downgrade the c# version to 4.0, because there is no difference in function except for grammatical differences.