### PR TITLE
Added support for NETStandard 1.5.

### DIFF
--- a/src/LibLog/LibLog.csproj
+++ b/src/LibLog/LibLog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
     <LangVersion>7</LangVersion>
     <RootNamespace>YourRootNamespace.Logging</RootNamespace>
   </PropertyGroup>

--- a/src/LibLog/LogProvider.cs
+++ b/src/LibLog/LogProvider.cs
@@ -46,6 +46,7 @@ using global::System.Diagnostics.CodeAnalysis;
 // that use LibLog
 namespace YourRootNamespace.Logging
 {
+    using System.Reflection;
     using global::System.Collections.Generic;
     using global::System.Diagnostics.CodeAnalysis;
     using global::YourRootNamespace.Logging.LogProviders;
@@ -114,8 +115,8 @@ namespace YourRootNamespace.Logging
         }
 
         internal static ILogProvider CurrentLogProvider
-        { 
-            get { return s_currentLogProvider; } 
+        {
+            get { return s_currentLogProvider; }
         }
 
         /// <summary>
@@ -128,11 +129,12 @@ namespace YourRootNamespace.Logging
 #else
         internal
 #endif
-        static ILog For<T>() 
+        static ILog For<T>()
         {
             return GetLogger(typeof(T));
         }
 
+#if !NETSTANDARD1_5
         /// <summary>
         /// Gets a logger for the current class.
         /// </summary>
@@ -148,6 +150,7 @@ namespace YourRootNamespace.Logging
             var stackFrame = new StackFrame(1, false);
             return GetLogger(stackFrame.GetMethod().DeclaringType);
         }
+#endif
 
         /// <summary>
         /// Gets a logger for the specified type.
@@ -288,7 +291,7 @@ namespace YourRootNamespace.Logging
             {
                 Console.WriteLine(
                     "Exception occurred resolving a log provider. Logging for this assembly {0} is disabled. {1}",
-                    typeof(LogProvider).Assembly.FullName,
+                    typeof(LogProvider).GetTypeInfo().Assembly.FullName,
                     ex);
             }
             return null;
@@ -303,8 +306,8 @@ namespace YourRootNamespace.Logging
             internal static readonly NoOpLogger Instance = new NoOpLogger();
 
             public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
-            { 
-                return false; 
+            {
+                return false;
             }
         }
 #endif

--- a/src/LibLog/LogProvider.cs.pp
+++ b/src/LibLog/LogProvider.cs.pp
@@ -41,16 +41,17 @@
 
 using global::System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes", Scope = "namespace", Target = "$rootnamespace$.Logging")]
-[assembly: SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Scope = "member", Target = "$rootnamespace$.Logging.Logger.#Invoke($rootnamespace$.Logging.LogLevel,System.Func`1<System.String>,System.Exception,System.Object[])")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes", Scope = "namespace", Target = "YourRootNamespace.Logging")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Scope = "member", Target = "YourRootNamespace.Logging.Logger.#Invoke(YourRootNamespace.Logging.LogLevel,System.Func`1<System.String>,System.Exception,System.Object[])")]
 
 // If you copied this file manually, you need to change all "YourRootNameSpace" so not to clash with other libraries
 // that use LibLog
 namespace $rootnamespace$.Logging
 {
+    using System.Reflection;
     using global::System.Collections.Generic;
     using global::System.Diagnostics.CodeAnalysis;
-    using global::$rootnamespace$.Logging.LogProviders;
+    using global::YourRootNamespace.Logging.LogProviders;
     using global::System;
 #if !LIBLOG_PROVIDERS_ONLY
     using global::System.Diagnostics;
@@ -116,8 +117,8 @@ namespace $rootnamespace$.Logging
         }
 
         internal static ILogProvider CurrentLogProvider
-        { 
-            get { return s_currentLogProvider; } 
+        {
+            get { return s_currentLogProvider; }
         }
 
         /// <summary>
@@ -130,11 +131,12 @@ namespace $rootnamespace$.Logging
 #else
         internal
 #endif
-        static ILog For<T>() 
+        static ILog For<T>()
         {
             return GetLogger(typeof(T));
         }
 
+#if !NETSTANDARD1_5
         /// <summary>
         /// Gets a logger for the current class.
         /// </summary>
@@ -150,6 +152,7 @@ namespace $rootnamespace$.Logging
             var stackFrame = new StackFrame(1, false);
             return GetLogger(stackFrame.GetMethod().DeclaringType);
         }
+#endif
 
         /// <summary>
         /// Gets a logger for the specified type.
@@ -290,7 +293,7 @@ namespace $rootnamespace$.Logging
             {
                 Console.WriteLine(
                     "Exception occurred resolving a log provider. Logging for this assembly {0} is disabled. {1}",
-                    typeof(LogProvider).Assembly.FullName,
+                    typeof(LogProvider).GetTypeInfo().Assembly.FullName,
                     ex);
             }
             return null;
@@ -305,8 +308,8 @@ namespace $rootnamespace$.Logging
             internal static readonly NoOpLogger Instance = new NoOpLogger();
 
             public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
-            { 
-                return false; 
+            {
+                return false;
             }
         }
 #endif

--- a/src/LibLog/LogProviders/Log4NetLogProvider.cs.pp
+++ b/src/LibLog/LogProviders/Log4NetLogProvider.cs.pp
@@ -39,9 +39,9 @@ namespace $rootnamespace$.Logging.LogProviders
         protected override OpenNdc GetOpenNdcMethod()
         {
             var logicalThreadContextType = FindType("log4net.LogicalThreadContext", "log4net");
-            var stacksProperty = logicalThreadContextType.GetProperty("Stacks");
+            var stacksProperty = logicalThreadContextType.GetTypeInfo().GetProperty("Stacks");
             var logicalThreadContextStacksType = stacksProperty.PropertyType;
-            var stacksIndexerProperty = logicalThreadContextStacksType.GetProperty("Item");
+            var stacksIndexerProperty = logicalThreadContextStacksType.GetTypeInfo().GetProperty("Item");
             var stackType = stacksIndexerProperty.PropertyType;
             var pushMethod = stackType.GetMethod("Push");
 
@@ -67,9 +67,9 @@ namespace $rootnamespace$.Logging.LogProviders
         protected override OpenMdc GetOpenMdcMethod()
         {
             var logicalThreadContextType = FindType("log4net.LogicalThreadContext", "log4net");
-            var propertiesProperty = logicalThreadContextType.GetProperty("Properties");
+            var propertiesProperty = logicalThreadContextType.GetTypeInfo().GetProperty("Properties");
             var logicalThreadContextPropertiesType = propertiesProperty.PropertyType;
-            var propertiesIndexerProperty = logicalThreadContextPropertiesType.GetProperty("Item");
+            var propertiesIndexerProperty = logicalThreadContextPropertiesType.GetTypeInfo().GetProperty("Item");
 
             var removeMethod = logicalThreadContextPropertiesType.GetMethod("Remove");
 
@@ -109,7 +109,11 @@ namespace $rootnamespace$.Logging.LogProviders
         private static Func<string, object> GetGetLoggerMethodCall()
         {
             var logManagerType = GetLogManagerType();
+#if !NETSTANDARD1_5
             var log4netAssembly = Assembly.GetAssembly(logManagerType);
+#else
+            var log4netAssembly = logManagerType.GetTypeInfo().Assembly;
+#endif
             var method = logManagerType.GetMethod("GetLogger", typeof(Assembly), typeof(string));
             var repositoryAssemblyParam = Expression.Parameter(typeof(Assembly), "repositoryAssembly");
             var nameParam = Expression.Parameter(typeof(string), "name");
@@ -144,7 +148,7 @@ namespace $rootnamespace$.Logging.LogProviders
             [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ILogger")]
             internal Log4NetLogger(object logger)
             {
-                _logger = logger.GetType().GetProperty("Logger").GetValue(logger);
+                _logger = logger.GetType().GetTypeInfo().GetProperty("Logger").GetValue(logger);
             }
 
             private static bool Initialize()
@@ -154,7 +158,7 @@ namespace $rootnamespace$.Logging.LogProviders
                     var logEventLevelType = FindType("log4net.Core.Level", "log4net");
                     if (logEventLevelType == null) throw new LibLogException("Type log4net.Core.Level was not found.");
 
-                    var levelFields = logEventLevelType.GetFields().ToList();
+                    var levelFields = logEventLevelType.GetTypeInfo().GetFields().ToList();
                     s_levelAll = levelFields.First(x => x.Name == "All").GetValue(null);
                     s_levelDebug = levelFields.First(x => x.Name == "Debug").GetValue(null);
                     s_levelInfo = levelFields.First(x => x.Name == "Info").GetValue(null);
@@ -226,8 +230,8 @@ namespace $rootnamespace$.Logging.LogProviders
                 var messageParam = Expression.Parameter(typeof(string));
                 var exceptionParam = Expression.Parameter(typeof(Exception));
 
-                var repositoryProperty = loggingEventType.GetProperty("Repository");
-                var levelProperty = loggingEventType.GetProperty("Level");
+                var repositoryProperty = loggingEventType.GetTypeInfo().GetProperty("Repository");
+                var levelProperty = loggingEventType.GetTypeInfo().GetProperty("Level");
 
                 var loggingEventConstructor =
                     loggingEventType.GetConstructorPortable(typeof(Type), repositoryProperty.PropertyType,
@@ -279,8 +283,8 @@ namespace $rootnamespace$.Logging.LogProviders
                 var keyParameter = Expression.Parameter(typeof(string), "key");
                 var valueParameter = Expression.Parameter(typeof(object), "value");
 
-                var propertiesProperty = loggingEventType.GetProperty("Properties");
-                var item = propertiesProperty.PropertyType.GetProperty("Item");
+                var propertiesProperty = loggingEventType.GetTypeInfo().GetProperty("Properties");
+                var item = propertiesProperty.PropertyType.GetTypeInfo().GetProperty("Item");
 
                 // ((LoggingEvent)loggingEvent).Properties[key] = value;
                 var body =
@@ -315,7 +319,7 @@ namespace $rootnamespace$.Logging.LogProviders
 
                 var callerStackBoundaryType = typeof(Log4NetLogger);
                 // Callsite HACK - Extract the callsite-logger-type from the messageFunc
-                var methodType = messageFunc.Method.DeclaringType;
+                var methodType = messageFunc.GetMethodInfo().DeclaringType;
                 if (methodType == typeof(LogExtensions) ||
                     methodType != null && methodType.DeclaringType == typeof(LogExtensions))
                     callerStackBoundaryType = typeof(LogExtensions);

--- a/src/LibLog/LogProviders/TraceEventTypeValues.cs
+++ b/src/LibLog/LogProviders/TraceEventTypeValues.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.Reflection;
 
 #if LIBLOG_EXCLUDE_CODE_COVERAGE
     [ExcludeFromCodeCoverage]
@@ -18,14 +19,14 @@
         [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
         static TraceEventTypeValues()
         {
-            var assembly = typeof(Uri).Assembly;
+            var assembly = typeof(Uri).GetTypeInfo().Assembly;
             Type = assembly.GetType("System.Diagnostics.TraceEventType");
             if (Type == null) return;
-            Verbose = (int) Enum.Parse(Type, "Verbose", false);
-            Information = (int) Enum.Parse(Type, "Information", false);
-            Warning = (int) Enum.Parse(Type, "Warning", false);
-            Error = (int) Enum.Parse(Type, "Error", false);
-            Critical = (int) Enum.Parse(Type, "Critical", false);
+            Verbose = (int)Enum.Parse(Type, "Verbose", false);
+            Information = (int)Enum.Parse(Type, "Information", false);
+            Warning = (int)Enum.Parse(Type, "Warning", false);
+            Error = (int)Enum.Parse(Type, "Error", false);
+            Critical = (int)Enum.Parse(Type, "Critical", false);
         }
     }
 }

--- a/src/LibLog/LogProviders/TraceEventTypeValues.cs.pp
+++ b/src/LibLog/LogProviders/TraceEventTypeValues.cs.pp
@@ -4,6 +4,7 @@ namespace $rootnamespace$.Logging.LogProviders
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.Reflection;
 
 #if LIBLOG_EXCLUDE_CODE_COVERAGE
     [ExcludeFromCodeCoverage]
@@ -20,14 +21,14 @@ namespace $rootnamespace$.Logging.LogProviders
         [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
         static TraceEventTypeValues()
         {
-            var assembly = typeof(Uri).Assembly;
+            var assembly = typeof(Uri).GetTypeInfo().Assembly;
             Type = assembly.GetType("System.Diagnostics.TraceEventType");
             if (Type == null) return;
-            Verbose = (int) Enum.Parse(Type, "Verbose", false);
-            Information = (int) Enum.Parse(Type, "Information", false);
-            Warning = (int) Enum.Parse(Type, "Warning", false);
-            Error = (int) Enum.Parse(Type, "Error", false);
-            Critical = (int) Enum.Parse(Type, "Critical", false);
+            Verbose = (int)Enum.Parse(Type, "Verbose", false);
+            Information = (int)Enum.Parse(Type, "Information", false);
+            Warning = (int)Enum.Parse(Type, "Warning", false);
+            Error = (int)Enum.Parse(Type, "Error", false);
+            Critical = (int)Enum.Parse(Type, "Critical", false);
         }
     }
 }

--- a/src/LibLog/LogProviders/TypeExtensions.cs
+++ b/src/LibLog/LogProviders/TypeExtensions.cs
@@ -12,7 +12,7 @@
     {
         internal static ConstructorInfo GetConstructorPortable(this Type type, params Type[] types)
         {
-            return type.GetConstructor(types);
+            return type.GetTypeInfo().GetConstructor(types);
         }
 
         internal static MethodInfo GetMethod(this Type type, string name, params Type[] types)

--- a/src/LibLog/LogProviders/TypeExtensions.cs.pp
+++ b/src/LibLog/LogProviders/TypeExtensions.cs.pp
@@ -14,7 +14,7 @@ namespace $rootnamespace$.Logging.LogProviders
     {
         internal static ConstructorInfo GetConstructorPortable(this Type type, params Type[] types)
         {
-            return type.GetConstructor(types);
+            return type.GetTypeInfo().GetConstructor(types);
         }
 
         internal static MethodInfo GetMethod(this Type type, string name, params Type[] types)

--- a/src/LibLog/LoggerExecutionWrapper.cs
+++ b/src/LibLog/LoggerExecutionWrapper.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.Reflection;
 
 #if LIBLOG_EXCLUDE_CODE_COVERAGE
     [ExcludeFromCodeCoverage]
@@ -35,7 +36,7 @@
             {
                 // Callsite HACK - Cache the last validated messageFunc as Equals is faster than type-check
                 lastExtensionMethod = null;
-                var methodType = messageFunc.Method.DeclaringType;
+                var methodType = messageFunc.GetMethodInfo().DeclaringType;
                 if (methodType == typeof(LogExtensions) ||
                     methodType != null && methodType.DeclaringType == typeof(LogExtensions))
                     lastExtensionMethod = messageFunc;
@@ -49,7 +50,7 @@
                     formatParameters);
             }
 
-            var WrappedMessageFunc = new Func<string>(() => 
+            var WrappedMessageFunc = new Func<string>(() =>
             {
                 try
                 {

--- a/src/LibLog/LoggerExecutionWrapper.cs.pp
+++ b/src/LibLog/LoggerExecutionWrapper.cs.pp
@@ -4,6 +4,7 @@ namespace $rootnamespace$.Logging
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.Reflection;
 
 #if LIBLOG_EXCLUDE_CODE_COVERAGE
     [ExcludeFromCodeCoverage]
@@ -37,7 +38,7 @@ namespace $rootnamespace$.Logging
             {
                 // Callsite HACK - Cache the last validated messageFunc as Equals is faster than type-check
                 lastExtensionMethod = null;
-                var methodType = messageFunc.Method.DeclaringType;
+                var methodType = messageFunc.GetMethodInfo().DeclaringType;
                 if (methodType == typeof(LogExtensions) ||
                     methodType != null && methodType.DeclaringType == typeof(LogExtensions))
                     lastExtensionMethod = messageFunc;
@@ -51,7 +52,7 @@ namespace $rootnamespace$.Logging
                     formatParameters);
             }
 
-            var WrappedMessageFunc = new Func<string>(() => 
+            var WrappedMessageFunc = new Func<string>(() =>
             {
                 try
                 {


### PR DESCRIPTION
As NETStandard 1.5 dosnt support transversing the Stack the GetCurrentClassLogger method on LogProvider will not be available.