### PR TITLE
Fix Doc Comments

### DIFF
--- a/src/LibLog/ILogProvider.cs
+++ b/src/LibLog/ILogProvider.cs
@@ -3,7 +3,7 @@
 namespace YourRootNamespace.Logging
 {
     /// <summary>
-    /// Represents a way to get a <see cref="ILog"/>
+    /// Represents a way to get a <see cref="Logger"/>
     /// </summary>
 #if LIBLOG_PROVIDERS_ONLY
     internal

--- a/src/LibLog/LogProvider.cs
+++ b/src/LibLog/LogProvider.cs
@@ -55,15 +55,19 @@ namespace YourRootNamespace.Logging
     using global::System.Runtime.CompilerServices;
 #endif
 
-    /// <summary>
-    /// Provides a mechanism to create instances of <see cref="ILog" /> objects.
-    /// </summary>
 #if LIBLOG_EXCLUDE_CODE_COVERAGE
     [ExcludeFromCodeCoverage]
 #endif
 #if LIBLOG_PROVIDERS_ONLY
+    /// <summary>
+    /// Provides a mechanism to set the <see cref="ILogProvider" />
+	/// and create instances of <see cref="ILog" /> objects. 
+    /// </summary>
     internal
 #else
+    /// <summary>
+    /// Provides a mechanism to set the <see cref="ILogProvider" />.
+    /// </summary>
     public
 #endif
     static class LogProvider


### PR DESCRIPTION
When using LibLog with Sandcastle Help File Builder with no extra defines, `Ilog` is internal. The `<summary>` comments for `LogProvider` and `ILogProvider` reference the internal type causing warnings. This PR corrects the XML documentation to avoid warnings when building documentation.